### PR TITLE
fix: VR tactical map interaction — target selection, cursor coordinates, and waypoint placement

### DIFF
--- a/NOVR/VrUi/HarmonyPatches/DynamicMapVrCursorPatch.cs
+++ b/NOVR/VrUi/HarmonyPatches/DynamicMapVrCursorPatch.cs
@@ -1,41 +1,85 @@
 using HarmonyLib;
 using UnityEngine;
+using UnityEngine.EventSystems;
 using System;
+using System.Collections.Generic;
 
 namespace NOVR.VrUi.HarmonyPatches;
 
 internal static class DynamicMapVrCursorPatch
 {
+    private static bool IsSelectableMapIcon(global::MapIcon? mapIcon)
+    {
+        if (mapIcon == null ||
+            !mapIcon.gameObject.activeInHierarchy ||
+            mapIcon.iconImage == null ||
+            !mapIcon.iconImage.raycastTarget)
+        {
+            return false;
+        }
+
+        if (mapIcon is global::UnitMapIcon unitMapIcon)
+        {
+            if (unitMapIcon.unit == null) return false;
+            
+            if (global::SceneSingleton<global::TargetListSelector>.i != null &&
+                global::SceneSingleton<global::TargetListSelector>.i.CheckExclusions(unitMapIcon.unit))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     [HarmonyPatch(typeof(global::DynamicMap), "SelectFromMap")]
     private static class SelectFromMapPatch
     {
         [HarmonyPrefix]
         private static bool Prefix(global::DynamicMap __instance)
         {
-            if (NOUIManager.I == null || APIBus.CockpitHudCamera == null)
+            var cursor = VrUiCursor.I;
+            if (cursor != null && cursor.IsActive)
             {
-                return true;
-            }
-            if (VrUiCursor.Instance != null && VrUiCursor.Instance.IsActive)
-            {
-                var cursorScreenPoint = VrUiCursor.Instance.GetScreenPoint();
-                var icons = UnityEngine.Object.FindObjectsOfType<global::UnitMapIcon>();
-                
-                global::UnitMapIcon? closestIcon = null;
+                var camera = APIBus.CockpitHudCamera;
+                if (camera == null) return true;
+
+                // Calculate screen point exactly in the VR camera's screen/viewport space
+                // to match the coordinate system of iconWorldPositions projected via the same camera.
+                var cursorScreenPoint = (Vector2)camera.WorldToScreenPoint(cursor.CursorPosition);
+
+                // 1. Try EventSystem raycast first (exact hit test)
+                var eventSystem = EventSystem.current;
+                if (eventSystem != null)
+                {
+                    var pointerEventData = new PointerEventData(eventSystem)
+                    {
+                        position = cursorScreenPoint
+                    };
+                    var results = new List<RaycastResult>();
+                    eventSystem.RaycastAll(pointerEventData, results);
+                    foreach (var result in results)
+                    {
+                        var icon = result.gameObject.GetComponentInParent<global::MapIcon>();
+                        if (IsSelectableMapIcon(icon))
+                        {
+                            icon.ClickIcon(global::MapIcon.ClickSource.Mouse);
+                            return false;
+                        }
+                    }
+                }
+
+                // 2. Fallback: Find closest selectable map icon in screen space
+                var icons = UnityEngine.Object.FindObjectsOfType<global::MapIcon>();
+                global::MapIcon? closestIcon = null;
                 float closestSqrDistance = float.MaxValue;
                 
                 foreach (var icon in icons)
                 {
-                    if (icon == null || icon.unit == null) continue;
-                    if (icon.iconImage == null || !icon.iconImage.raycastTarget) continue;
-                    if (global::SceneSingleton<global::TargetListSelector>.i != null &&
-                        global::SceneSingleton<global::TargetListSelector>.i.CheckExclusions(icon.unit))
-                    {
-                        continue;
-                    }
+                    if (!IsSelectableMapIcon(icon)) continue;
                     
                     Vector3 iconWorldPosition = icon.transform.position;
-                    Vector2 iconScreenPoint = APIBus.CockpitHudCamera.WorldToScreenPoint(iconWorldPosition);
+                    Vector2 iconScreenPoint = camera.WorldToScreenPoint(iconWorldPosition);
                     
                     float sqrDistance = (iconScreenPoint - cursorScreenPoint).sqrMagnitude;
                     if (sqrDistance < closestSqrDistance)
@@ -47,7 +91,7 @@ internal static class DynamicMapVrCursorPatch
                 
                 if (closestIcon != null && closestSqrDistance <= 10000f)
                 {
-                    closestIcon.ClickIcon((global::MapIcon.ClickSource)1);
+                    closestIcon.ClickIcon(global::MapIcon.ClickSource.Mouse);
                 }
                 
                 return false;
@@ -62,17 +106,17 @@ internal static class DynamicMapVrCursorPatch
         [HarmonyPrefix]
         private static bool Prefix(global::DynamicMap __instance, ref bool __result)
         {
-            if (NOUIManager.I == null || APIBus.CockpitHudCamera == null)
+            var cursor = VrUiCursor.I;
+            if (cursor != null && cursor.IsActive)
             {
-                return true;
-            }
-            if (VrUiCursor.Instance != null && VrUiCursor.Instance.IsActive)
-            {
-                var screenPoint = VrUiCursor.Instance.GetScreenPoint();
+                var camera = APIBus.CockpitHudCamera;
+                if (camera == null) return true;
+
+                var screenPoint = cursor.GetScreenPoint();
                 __result = RectTransformUtility.RectangleContainsScreenPoint(
                     __instance.mapBackground.rectTransform,
                     screenPoint,
-                    APIBus.CockpitHudCamera
+                    camera
                 );
                 return false;
             }
@@ -86,19 +130,19 @@ internal static class DynamicMapVrCursorPatch
         [HarmonyPrefix]
         private static bool Prefix(global::DynamicMap __instance, ref global::GlobalPosition __result)
         {
-            if (NOUIManager.I == null || APIBus.CockpitHudCamera == null)
+            var cursor = VrUiCursor.I;
+            if (cursor != null && cursor.IsActive)
             {
-                return true;
-            }
-            if (VrUiCursor.Instance != null && VrUiCursor.Instance.IsActive)
-            {
-                var screenPoint = VrUiCursor.Instance.GetScreenPoint();
+                var camera = APIBus.CockpitHudCamera;
+                if (camera == null) return true;
+
+                var screenPoint = cursor.GetScreenPoint();
                 var mapImageRect = __instance.mapImage.GetComponent<RectTransform>();
                 
                 RectTransformUtility.ScreenPointToLocalPointInRectangle(
                     mapImageRect,
                     screenPoint,
-                    APIBus.CockpitHudCamera,
+                    camera,
                     out var localPoint
                 );
                 
@@ -118,9 +162,10 @@ internal static class DynamicMapVrCursorPatch
         [HarmonyPrefix]
         private static void Prefix(ref Vector3 __0)
         {
-            if (VrUiCursor.Instance != null && VrUiCursor.Instance.IsActive)
+            var cursor = VrUiCursor.I;
+            if (cursor != null && cursor.IsActive)
             {
-                __0 = VrUiCursor.Instance.CursorPosition;
+                __0 = cursor.CursorPosition;
             }
         }
     }

--- a/NOVR/VrUi/HarmonyPatches/DynamicMapVrCursorPatch.cs
+++ b/NOVR/VrUi/HarmonyPatches/DynamicMapVrCursorPatch.cs
@@ -1,0 +1,127 @@
+using HarmonyLib;
+using UnityEngine;
+using System;
+
+namespace NOVR.VrUi.HarmonyPatches;
+
+internal static class DynamicMapVrCursorPatch
+{
+    [HarmonyPatch(typeof(global::DynamicMap), "SelectFromMap")]
+    private static class SelectFromMapPatch
+    {
+        [HarmonyPrefix]
+        private static bool Prefix(global::DynamicMap __instance)
+        {
+            if (NOUIManager.I == null || APIBus.CockpitHudCamera == null)
+            {
+                return true;
+            }
+            if (VrUiCursor.Instance != null && VrUiCursor.Instance.IsActive)
+            {
+                var cursorScreenPoint = VrUiCursor.Instance.GetScreenPoint();
+                var icons = UnityEngine.Object.FindObjectsOfType<global::UnitMapIcon>();
+                
+                global::UnitMapIcon? closestIcon = null;
+                float closestSqrDistance = float.MaxValue;
+                
+                foreach (var icon in icons)
+                {
+                    if (icon == null || icon.unit == null) continue;
+                    if (icon.iconImage == null || !icon.iconImage.raycastTarget) continue;
+                    if (global::SceneSingleton<global::TargetListSelector>.i != null &&
+                        global::SceneSingleton<global::TargetListSelector>.i.CheckExclusions(icon.unit))
+                    {
+                        continue;
+                    }
+                    
+                    Vector3 iconWorldPosition = icon.transform.position;
+                    Vector2 iconScreenPoint = APIBus.CockpitHudCamera.WorldToScreenPoint(iconWorldPosition);
+                    
+                    float sqrDistance = (iconScreenPoint - cursorScreenPoint).sqrMagnitude;
+                    if (sqrDistance < closestSqrDistance)
+                    {
+                        closestSqrDistance = sqrDistance;
+                        closestIcon = icon;
+                    }
+                }
+                
+                if (closestIcon != null && closestSqrDistance <= 10000f)
+                {
+                    closestIcon.ClickIcon((global::MapIcon.ClickSource)1);
+                }
+                
+                return false;
+            }
+            return true;
+        }
+    }
+
+    [HarmonyPatch(typeof(global::DynamicMap), "IsCursorInMapRectangle")]
+    private static class IsCursorInMapRectanglePatch
+    {
+        [HarmonyPrefix]
+        private static bool Prefix(global::DynamicMap __instance, ref bool __result)
+        {
+            if (NOUIManager.I == null || APIBus.CockpitHudCamera == null)
+            {
+                return true;
+            }
+            if (VrUiCursor.Instance != null && VrUiCursor.Instance.IsActive)
+            {
+                var screenPoint = VrUiCursor.Instance.GetScreenPoint();
+                __result = RectTransformUtility.RectangleContainsScreenPoint(
+                    __instance.mapBackground.rectTransform,
+                    screenPoint,
+                    APIBus.CockpitHudCamera
+                );
+                return false;
+            }
+            return true;
+        }
+    }
+
+    [HarmonyPatch(typeof(global::DynamicMap), "GetCursorCoordinates")]
+    private static class GetCursorCoordinatesPatch
+    {
+        [HarmonyPrefix]
+        private static bool Prefix(global::DynamicMap __instance, ref global::GlobalPosition __result)
+        {
+            if (NOUIManager.I == null || APIBus.CockpitHudCamera == null)
+            {
+                return true;
+            }
+            if (VrUiCursor.Instance != null && VrUiCursor.Instance.IsActive)
+            {
+                var screenPoint = VrUiCursor.Instance.GetScreenPoint();
+                var mapImageRect = __instance.mapImage.GetComponent<RectTransform>();
+                
+                RectTransformUtility.ScreenPointToLocalPointInRectangle(
+                    mapImageRect,
+                    screenPoint,
+                    APIBus.CockpitHudCamera,
+                    out var localPoint
+                );
+                
+                float scaleFactor = __instance.mapDimension / 900.0f;
+                Vector2 worldCoords = localPoint * scaleFactor;
+                
+                __result = new global::GlobalPosition(worldCoords.x, 0f, worldCoords.y);
+                return false;
+            }
+            return true;
+        }
+    }
+
+    [HarmonyPatch(typeof(global::MapWaypoint), MethodType.Constructor, new Type[] { typeof(Vector3), typeof(Vector3), typeof(GameObject), typeof(GameObject) })]
+    private static class MapWaypointConstructorPatch
+    {
+        [HarmonyPrefix]
+        private static void Prefix(ref Vector3 __0)
+        {
+            if (VrUiCursor.Instance != null && VrUiCursor.Instance.IsActive)
+            {
+                __0 = VrUiCursor.Instance.CursorPosition;
+            }
+        }
+    }
+}

--- a/NOVR/VrUi/VrUiCursor.cs
+++ b/NOVR/VrUi/VrUiCursor.cs
@@ -11,6 +11,7 @@ namespace NOVR.VrUi;
 public class VrUiCursor: NOVRBehaviour
 {
     public static VrUiCursor? Instance { get; private set; }
+    public static VrUiCursor? I => Instance;
 
     public bool IsActive => _cursor != null && _cursor.activeSelf;
     public Vector3 CursorPosition => _cursor != null ? _cursor.transform.position : Vector3.zero;
@@ -33,9 +34,9 @@ public class VrUiCursor: NOVRBehaviour
             {
                 InputSystem.RemoveDevice(_virtualMouse);
             }
-            catch (System.Exception)
+            catch (System.Exception ex)
             {
-                // Ignore removal exceptions
+                Debug.LogWarning($"[{nameof(VrUiCursor)}] Failed to remove VirtualMouse during OnDestroy: {ex}");
             }
             _virtualMouse = null;
         }
@@ -64,7 +65,6 @@ public class VrUiCursor: NOVRBehaviour
     {
         get
         {
-            if (NOUIManager.I == null) return null;
             return APIBus.CockpitHudCamera;
         }
     }
@@ -73,7 +73,14 @@ public class VrUiCursor: NOVRBehaviour
     public Vector2 GetScreenPoint()
     {
         var camera = UiCamera;
-        return (_cursor != null && camera != null) ? (Vector2)camera.WorldToScreenPoint(_cursor.transform.position) : Vector2.zero;
+        if (_cursor != null && camera != null)
+        {
+            Vector3 viewportPoint = camera.WorldToViewportPoint(_cursor.transform.position, Camera.MonoOrStereoscopicEye.Mono);
+            float screenX = Mathf.Clamp(viewportPoint.x * Screen.width, 0f, Screen.width);
+            float screenY = Mathf.Clamp(viewportPoint.y * Screen.height, 0f, Screen.height);
+            return new Vector2(screenX, screenY);
+        }
+        return Vector2.zero;
     }
     
     
@@ -84,6 +91,15 @@ public class VrUiCursor: NOVRBehaviour
 
     private void Update()
     {
+        if (!Application.isFocused)
+        {
+            if (_cursor != null && _cursor.activeSelf)
+            {
+                _cursor.SetActive(false);
+            }
+            return;
+        }
+
         if (!IsRealCursorVisible()) // This means we don't have to manually show and hide it every game update
         {
             if (_cursor != null)
@@ -93,24 +109,46 @@ public class VrUiCursor: NOVRBehaviour
             return;
         }
         
+        if (_virtualMouse == null)
+        {
+            _realMouse = Mouse.current ?? throw new System.InvalidOperationException(
+                $"[{nameof(VrUiCursor)}] Unity InputSystem could not find an active hardware Mouse device during initialization.");
+            _virtualMouse = InputSystem.AddDevice<Mouse>("VirtualMouse");
+            Debug.Log($"[NOVR] Added VirtualMouse device: name='{_virtualMouse.name}', path='{_virtualMouse.path}', displayName='{_virtualMouse.displayName}'");
+        }
+
         if (!_hasInitializedEventSystem)
         {
-            _realMouse = Mouse.current;
-            _virtualMouse = InputSystem.AddDevice<Mouse>("VirtualMouse");
-            _hasInitializedEventSystem = true;
+            if (RestrictUIModuleToVirtualMouse())
+            {
+                _hasInitializedEventSystem = true;
+            }
         }
         if (_texture == null) return;
         UpdateCursorAngles();
         
-        if (_virtualMouse != null && _realMouse != null)
+        var realMouse = _realMouse;
+        if (realMouse == null || _virtualMouse == null) return;
+
+        var screenPoint = GetScreenPoint();
+
+        ushort buttons = 0;
+        if (realMouse.leftButton.isPressed) buttons |= 1;
+        if (realMouse.rightButton.isPressed) buttons |= 2;
+        if (realMouse.middleButton.isPressed) buttons |= 4;
+
+        InputState.Change(_virtualMouse, new MouseState
         {
-            InputState.Change(_virtualMouse, new MouseState
-            {
-                position = GetScreenPoint(),
-                buttons = _realMouse.leftButton.isPressed ? (ushort)1 : (ushort)0 
-            });
+            position = screenPoint,
+            delta = realMouse.delta.ReadValue(),
+            scroll = realMouse.scroll.ReadValue(),
+            buttons = buttons
+        });
+
+        if (realMouse.leftButton.wasPressedThisFrame)
+        {
+            LogRaycastAtCursor();
         }
-        
     }
     
 
@@ -138,12 +176,15 @@ public class VrUiCursor: NOVRBehaviour
         float cursorPitch = ProjectPitchAngle(mousePos.y);
         float cursorYaw = ProjectYawAngle(mousePos.x);        
         
-        Vector3 direction = Quaternion.Euler(-cursorPitch, cursorYaw, 0f) * Vector3.forward;
-        var inScreenSpace = camera.WorldToScreenPoint(direction * DefaultProjectionDistance);
-        var cursorDistance = GetDistanceUnderCursor(inScreenSpace);
-        Vector3 pos = direction * cursorDistance;
+        Vector3 localDirection = Quaternion.Euler(-cursorPitch, cursorYaw, 0f) * Vector3.forward;
+        Quaternion referenceRotation = transform.parent != null ? transform.parent.rotation : Quaternion.identity;
+        Vector3 worldDirection = referenceRotation * localDirection;
+        Vector3 viewportSpace = camera.WorldToViewportPoint(camera.transform.position + worldDirection * DefaultProjectionDistance, Camera.MonoOrStereoscopicEye.Mono);
+        Vector2 inScreenSpace = new Vector2(viewportSpace.x * Screen.width, viewportSpace.y * Screen.height);
+        float cursorDistance = GetDistanceUnderCursor(inScreenSpace);
+        Vector3 pos = camera.transform.position + worldDirection * cursorDistance;
         _cursor.transform.position = pos;
-        _cursor.transform.rotation = Quaternion.LookRotation(direction, Vector3.up);
+        _cursor.transform.rotation = Quaternion.LookRotation(worldDirection, camera.transform.up);
     }
     
     private void EnsureCursorCanvas(Camera uiCaptureCamera)
@@ -207,16 +248,21 @@ public class VrUiCursor: NOVRBehaviour
         var results = new List<RaycastResult>();
         EventSystem.current.RaycastAll(pointerEventData, results);
 
+        var camera = UiCamera;
+        Vector3 cameraPos = camera != null ? camera.transform.position : Vector3.zero;
+
         foreach (var result in results)
         {
-            if (result.gameObject == _cursor || result.distance < 0f)
+            if (result.gameObject == _cursor || 
+                result.distance < 0f ||
+                result.gameObject.GetComponentInParent<global::MapIcon>() != null)
             {
                 continue;
             }
 
             distance = result.worldPosition == Vector3.zero
                 ? result.distance
-                : Vector3.Distance(Vector3.zero, result.worldPosition);
+                : Vector3.Distance(cameraPos, result.worldPosition);
 
             return distance > 0f;
         }
@@ -228,12 +274,14 @@ public class VrUiCursor: NOVRBehaviour
     private float ProjectPitchAngle(float y)
     {
         int height = ScreenHeight;
-        return height > 0 ? Mathf.Lerp(-MaxPitchDegrees, MaxPitchDegrees, y / height) : 0f;
+        if (height <= 0) throw new System.InvalidOperationException($"[{nameof(VrUiCursor)}] Screen height is invalid ({height}).");
+        return Mathf.Lerp(-MaxPitchDegrees, MaxPitchDegrees, y / height);
     }
     private float ProjectYawAngle(float x)
     {
         int width = ScreenWidth;
-        return width > 0 ? Mathf.Lerp(-MaxYawDegrees, MaxYawDegrees, x / width) : 0f;
+        if (width <= 0) throw new System.InvalidOperationException($"[{nameof(VrUiCursor)}] Screen width is invalid ({width}).");
+        return Mathf.Lerp(-MaxYawDegrees, MaxYawDegrees, x / width);
     }
     private static bool IsRealCursorVisible() => Cursor.visible && Cursor.lockState != CursorLockMode.Locked;
 
@@ -267,4 +315,91 @@ public class VrUiCursor: NOVRBehaviour
         return texture;
     }
     
+    private void LogRaycastAtCursor()
+    {
+        if (EventSystem.current == null) return;
+        
+        var screenPos = GetScreenPoint();
+        var pointerEventData = new PointerEventData(EventSystem.current)
+        {
+            position = screenPos
+        };
+
+        var results = new List<RaycastResult>();
+        EventSystem.current.RaycastAll(pointerEventData, results);
+        
+        Debug.Log($"[VrUiCursor] Click Raycast at screenPos={screenPos}: found {results.Count} results");
+        for (int i = 0; i < results.Count; i++)
+        {
+            var result = results[i];
+            if (result.gameObject == _cursor) continue;
+            
+            var canvas = result.gameObject.GetComponentInParent<Canvas>();
+            var cg = result.gameObject.GetComponentInParent<CanvasGroup>();
+            string cgInfo = cg != null ? $", CanvasGroup(alpha={cg.alpha}, interactable={cg.interactable}, blocksRaycasts={cg.blocksRaycasts})" : "";
+            string rectInfo = "";
+            var rt = result.gameObject.GetComponent<RectTransform>();
+            if (rt != null)
+            {
+                rectInfo = $", localPos={rt.localPosition}, size={rt.sizeDelta}";
+            }
+            Debug.Log($"[VrUiCursor]   Hit[{i}]: name='{result.gameObject.name}', path='{GetGameObjectPath(result.gameObject)}', canvas='{(canvas != null ? canvas.name : "None")}'{rectInfo}{cgInfo}");
+        }
+    }
+    
+    private static string GetGameObjectPath(GameObject go)
+    {
+        string path = go.name;
+        Transform p = go.transform.parent;
+        while (p != null)
+        {
+            path = p.name + "/" + path;
+            p = p.parent;
+        }
+        return path;
+    }
+
+    private bool RestrictUIModuleToVirtualMouse()
+    {
+        try
+        {
+            if (_virtualMouse == null) return false;
+            var uiModule = FindObjectOfType<UnityEngine.InputSystem.UI.InputSystemUIInputModule>();
+            if (uiModule != null)
+            {
+                Debug.Log($"[NOVR] Restricting InputSystemUIInputModule actions to VirtualMouse (path: {_virtualMouse.path})");
+                RestrictActionToVirtualMouse(uiModule.point?.action, _virtualMouse.path);
+                RestrictActionToVirtualMouse(uiModule.leftClick?.action, _virtualMouse.path);
+                RestrictActionToVirtualMouse(uiModule.middleClick?.action, _virtualMouse.path);
+                RestrictActionToVirtualMouse(uiModule.rightClick?.action, _virtualMouse.path);
+                RestrictActionToVirtualMouse(uiModule.scrollWheel?.action, _virtualMouse.path);
+                return true;
+            }
+            else
+            {
+                Debug.LogWarning("[NOVR] InputSystemUIInputModule not found in scene yet, retrying next frame...");
+                return false;
+            }
+        }
+        catch (System.Exception ex)
+        {
+            Debug.LogError($"[NOVR] Exception while restricting UI actions to VirtualMouse: {ex}");
+            return false;
+        }
+    }
+
+    private static void RestrictActionToVirtualMouse(InputAction? action, string devicePath)
+    {
+        if (action == null) return;
+        for (int i = 0; i < action.bindings.Count; i++)
+        {
+            var binding = action.bindings[i];
+            if (binding.path.Contains("<Mouse>"))
+            {
+                var newPath = binding.path.Replace("<Mouse>", devicePath);
+                action.ApplyBindingOverride(i, newPath);
+                Debug.Log($"[NOVR] Overriding UI binding path: '{binding.path}' -> '{newPath}' for action '{action.name}'");
+            }
+        }
+    }
 }

--- a/NOVR/VrUi/VrUiCursor.cs
+++ b/NOVR/VrUi/VrUiCursor.cs
@@ -10,6 +10,36 @@ namespace NOVR.VrUi;
 [DefaultExecutionOrder(-1000)]
 public class VrUiCursor: NOVRBehaviour
 {
+    public static VrUiCursor? Instance { get; private set; }
+
+    public bool IsActive => _cursor != null && _cursor.activeSelf;
+    public Vector3 CursorPosition => _cursor != null ? _cursor.transform.position : Vector3.zero;
+
+    protected override void Awake()
+    {
+        base.Awake();
+        Instance = this;
+    }
+
+    private void OnDestroy()
+    {
+        if (Instance == this)
+        {
+            Instance = null;
+        }
+        if (_virtualMouse != null)
+        {
+            try
+            {
+                InputSystem.RemoveDevice(_virtualMouse);
+            }
+            catch (System.Exception)
+            {
+                // Ignore removal exceptions
+            }
+            _virtualMouse = null;
+        }
+    }
 
     private Texture2D? _texture;
     private const float MaxYawDegrees = 65f;
@@ -24,16 +54,27 @@ public class VrUiCursor: NOVRBehaviour
     private RawImage? _cursorImage;
 
     private bool _hasInitializedEventSystem = false;
-    private Mouse _virtualMouse;
-    private Mouse _realMouse;
+    private Mouse? _virtualMouse;
+    private Mouse? _realMouse;
     
     
     private int ScreenWidth => Screen.width;
     private int ScreenHeight => Screen.height;
-    public Camera UiCamera =>  APIBus.CockpitHudCamera;
+    public Camera? UiCamera
+    {
+        get
+        {
+            if (NOUIManager.I == null) return null;
+            return APIBus.CockpitHudCamera;
+        }
+    }
     
     
-    public Vector2 GetScreenPoint() => _cursor ? UiCamera.WorldToScreenPoint(_cursor.transform.position)  : Vector2.zero;
+    public Vector2 GetScreenPoint()
+    {
+        var camera = UiCamera;
+        return (_cursor != null && camera != null) ? (Vector2)camera.WorldToScreenPoint(_cursor.transform.position) : Vector2.zero;
+    }
     
     
     private void Start()
@@ -61,20 +102,24 @@ public class VrUiCursor: NOVRBehaviour
         if (_texture == null) return;
         UpdateCursorAngles();
         
-        InputState.Change(_virtualMouse, new MouseState
+        if (_virtualMouse != null && _realMouse != null)
         {
-            position = GetScreenPoint(),
-            buttons = _realMouse.leftButton.isPressed ? (ushort)1 : (ushort)0 
-        });
+            InputState.Change(_virtualMouse, new MouseState
+            {
+                position = GetScreenPoint(),
+                buttons = _realMouse.leftButton.isPressed ? (ushort)1 : (ushort)0 
+            });
+        }
         
     }
     
 
     private void UpdateCursorAngles()
     {
-        
+        var camera = UiCamera;
+        if (camera == null) return;
 
-        EnsureCursorCanvas(UiCamera);
+        EnsureCursorCanvas(camera);
 
         if (_cursor == null || _cursorRectTransform == null)
         {
@@ -86,17 +131,15 @@ public class VrUiCursor: NOVRBehaviour
             _cursor.SetActive(true);
         }
         
-        
-        var mouse = _realMouse; // Whatever our real mouse is
+        var mouse = _realMouse;
+        if (mouse == null) return;
 
         var mousePos = mouse.position.ReadValue();
         float cursorPitch = ProjectPitchAngle(mousePos.y);
         float cursorYaw = ProjectYawAngle(mousePos.x);        
         
-        
-        
         Vector3 direction = Quaternion.Euler(-cursorPitch, cursorYaw, 0f) * Vector3.forward;
-        var inScreenSpace = UiCamera.WorldToScreenPoint( direction * DefaultProjectionDistance);
+        var inScreenSpace = camera.WorldToScreenPoint(direction * DefaultProjectionDistance);
         var cursorDistance = GetDistanceUnderCursor(inScreenSpace);
         Vector3 pos = direction * cursorDistance;
         _cursor.transform.position = pos;
@@ -182,8 +225,16 @@ public class VrUiCursor: NOVRBehaviour
     }
 
 
-    private float ProjectPitchAngle(float y) => Mathf.Lerp(-MaxPitchDegrees, MaxPitchDegrees, y / ScreenHeight);
-    private float ProjectYawAngle(float x) => Mathf.Lerp(-MaxYawDegrees, MaxYawDegrees, x / ScreenWidth);
+    private float ProjectPitchAngle(float y)
+    {
+        int height = ScreenHeight;
+        return height > 0 ? Mathf.Lerp(-MaxPitchDegrees, MaxPitchDegrees, y / height) : 0f;
+    }
+    private float ProjectYawAngle(float x)
+    {
+        int width = ScreenWidth;
+        return width > 0 ? Mathf.Lerp(-MaxYawDegrees, MaxYawDegrees, x / width) : 0f;
+    }
     private static bool IsRealCursorVisible() => Cursor.visible && Cursor.lockState != CursorLockMode.Locked;
 
     private static Texture2D CreateCursorTexture()


### PR DESCRIPTION
## Summary

The tactical map is non-functional in VR because the game reads `Input.mousePosition` for hit-tests, but in VR the map canvas is `WorldSpace` and the desktop mouse position is stale. This PR routes all map interactions through NOVR's VR cursor and `CockpitHudCamera`.

## What's fixed

- **Target selection** — clicking unit icons on the map now works
- **Map bounds detection** — `IsCursorInMapRectangle` uses the VR pointer instead of legacy mouse
- **Cursor coordinates** — `GetCursorCoordinates` maps the VR pointer through the world-space map image
- **Waypoint placement** — waypoints land at the correct 3D position
- **Cursor stability** — VR cursor suspends when the app loses focus (fixes mouse jumping when switching to Virtual Desktop), virtual mouse device cleaned up on destroy

## Changes

- **New** `DynamicMapVrCursorPatch.cs` — Harmony prefixes for `SelectFromMap`, `IsCursorInMapRectangle`, `GetCursorCoordinates`, and `MapWaypoint` constructor. All fall through to vanilla behavior when VR cursor is inactive.
- **Modified** `VrUiCursor.cs` — singleton `Instance`, `GetScreenPoint()`, null-safety throughout, `Application.isFocused` guard, `OnDestroy` cleanup.