### PR TITLE
Fix VR dynamic map cursor hit tests

### DIFF
--- a/MAP_CURSOR_TESTING.md
+++ b/MAP_CURSOR_TESTING.md
@@ -4,6 +4,75 @@ Branch: `vr-map-input-fix`
 
 This branch targets the Nuclear Option map issue where NOVR's VR cursor can hover/highlight map aircraft, but clicking them is rejected or behaves inconsistently.
 
+## Next Codex Session Handoff
+
+Start here on the Windows/headset machine.
+
+1. Open a shell in the repo or clone the fork:
+
+   ```powershell
+   git clone https://github.com/georgeciobanu/novr.git
+   cd novr
+   git switch vr-map-input-fix
+   ```
+
+   If the repo already exists:
+
+   ```powershell
+   git fetch george
+   git switch vr-map-input-fix
+   git pull
+   ```
+
+2. Build:
+
+   ```powershell
+   dotnet restore
+   dotnet build
+   ```
+
+3. Install the built plugin:
+
+   ```text
+   build-output/plugins/NOVR.dll
+   ```
+
+   Replace:
+
+   ```text
+   <Nuclear Option install>/BepInEx/plugins/NOVR.dll
+   ```
+
+4. Launch Nuclear Option in VR and collect:
+
+   ```text
+   <Nuclear Option install>/BepInEx/LogOutput.log
+   ```
+
+   Search for:
+
+   ```text
+   NOVR DynamicMap cursor:
+   ```
+
+5. First test with default branch settings:
+
+   ```ini
+   [UI]
+   Dynamic Map VR Cursor Fix Enabled = true
+
+   [Diagnostics]
+   Dynamic Map VR Cursor Diagnostics Enabled = true
+   ```
+
+6. If map clicks still fail, keep diagnostics enabled and capture logs for:
+   - hover aircraft, click aircraft;
+   - click `Select Aircraft`;
+   - one normal 16:9 resolution;
+   - one ultrawide/native monitor resolution.
+
+The Mac session committed and pushed this branch but did not produce a reliable DLL because the Mac-side local reference set was missing Unity's JSON serialization module for the vendored OpenXR project. Build on the Windows/game machine is the source of truth.
+
 ## What Changed
 
 - `NOVR/VrUi/VrUiPointerState.cs`

--- a/MAP_CURSOR_TESTING.md
+++ b/MAP_CURSOR_TESTING.md
@@ -1,0 +1,126 @@
+# Dynamic Map VR Cursor Fix
+
+Branch: `vr-map-input-fix`
+
+This branch targets the Nuclear Option map issue where NOVR's VR cursor can hover/highlight map aircraft, but clicking them is rejected or behaves inconsistently.
+
+## What Changed
+
+- `NOVR/VrUi/VrUiPointerState.cs`
+  - Stores NOVR's current VR UI screen point and the real mouse point each frame.
+- `NOVR/VrUi/VrUiCursor.cs`
+  - Publishes the screen point it already sends to the `VirtualMouse`.
+- `NOVR/VrUi/HarmonyPatches/DynamicMapVrCursorPatch.cs`
+  - Patches `DynamicMap.IsCursorInMapRectangle()` to use NOVR's VR pointer instead of legacy `Input.mousePosition`.
+  - Patches `DynamicMap.GetCursorCoordinates()` to convert the VR pointer through the world-space map image.
+  - Patches the private `DynamicMap.SelectFromMap()` path so controller-style select uses the VR pointer and does not accidentally select from stale real mouse coordinates.
+  - Logs map click diagnostics.
+- `NOVR/ModConfiguration.cs`
+  - Adds config flags for the fix and diagnostics.
+
+## Config Flags
+
+After first launch, BepInEx should create or update:
+
+`BepInEx/config/deltawing.novr.cfg`
+
+Relevant keys:
+
+```ini
+[UI]
+Dynamic Map VR Cursor Fix Enabled = true
+
+[Diagnostics]
+Dynamic Map VR Cursor Diagnostics Enabled = true
+```
+
+Diagnostics default to `true` on this branch for testing. Turn them off after collecting logs.
+
+## Expected Logs
+
+Look in:
+
+`BepInEx/LogOutput.log`
+
+Search for:
+
+```text
+NOVR DynamicMap cursor:
+```
+
+Useful cases to capture:
+
+- Hover an aircraft, click it, and note whether selection succeeds.
+- Click the `Select Aircraft` button if it is still finicky.
+- Try one normal 16:9 game/window resolution and one ultrawide/native monitor mode.
+
+Important fields in the log:
+
+- `vrPoint`: NOVR's virtual UI pointer.
+- `realMouse`: Unity legacy mouse position.
+- `vrInMap`: whether the patched VR pointer is inside the map rectangle.
+- `realInMap`: whether the original legacy mouse position is inside the map rectangle.
+- `hit`: selected or clicked map icon name if found.
+- `screen`: Unity `Screen.width` x `Screen.height`.
+
+If `vrInMap=true` and `realInMap=false`, this branch is fixing the exact mixed-input bug.
+
+## Windows Build
+
+From the repo root:
+
+```powershell
+git fetch
+git switch vr-map-input-fix
+dotnet restore
+dotnet build
+```
+
+Expected plugin output is under:
+
+```text
+build-output/plugins/
+```
+
+The main file to install/test is:
+
+```text
+build-output/plugins/NOVR.dll
+```
+
+If the build fails on `JsonUtility`, make sure the game/Unity managed reference set includes:
+
+```text
+NuclearOption_Data/Managed/UnityEngine.JSONSerializeModule.dll
+```
+
+The Mac-side repo did not have that module in `lib/mono/modern`, so local build validation stopped at the vendored OpenXR project before producing a DLL.
+
+## Manual Install
+
+Back up the currently installed NOVR DLL, then replace it with the built `NOVR.dll`:
+
+```text
+<Nuclear Option install>/BepInEx/plugins/NOVR.dll
+```
+
+Keep the same plugin ID (`deltawing.novr`) so BepInEx uses the same config file.
+
+## Test Matrix
+
+1. Start with both flags enabled.
+2. Open the map in VR.
+3. Hover an aircraft until it highlights or shows tooltip.
+4. Left click it.
+5. Press the relevant select/control input if you normally use one.
+6. Try the `Select Aircraft` button.
+7. Repeat at a known-good 16:9 resolution and at the ultrawide resolution.
+
+Then test fallback:
+
+```ini
+[UI]
+Dynamic Map VR Cursor Fix Enabled = false
+```
+
+That should restore original NOVR behavior while keeping diagnostics available if the diagnostics flag remains true.

--- a/NOVR/ModConfiguration.cs
+++ b/NOVR/ModConfiguration.cs
@@ -11,6 +11,8 @@ public class ModConfiguration
 
     public readonly ConfigFile Config;
     public readonly ConfigEntry<float> TargetDesignatorOvershoot;
+    public readonly ConfigEntry<bool> DynamicMapVrCursorFixEnabled;
+    public readonly ConfigEntry<bool> DynamicMapVrCursorDiagnosticsEnabled;
 
     public ModConfiguration(ConfigFile config)
     {
@@ -22,5 +24,17 @@ public class ModConfiguration
             "Target Designator Overshoot",
             1.2f,
             "How much the target designator should multiply rotation to make for easier high off boresight target designation. Set to 1.0 to disable");
+
+        DynamicMapVrCursorFixEnabled = config.Bind(
+            "UI",
+            "Dynamic Map VR Cursor Fix Enabled",
+            true,
+            "Use NOVR's VR cursor position for DynamicMap hit tests that normally read UnityEngine.Input.mousePosition.");
+
+        DynamicMapVrCursorDiagnosticsEnabled = config.Bind(
+            "Diagnostics",
+            "Dynamic Map VR Cursor Diagnostics Enabled",
+            true,
+            "Log DynamicMap VR cursor hit-test details when map icons are clicked or selected.");
     }
 }

--- a/NOVR/VrUi/HarmonyPatches/DynamicMapVrCursorPatch.cs
+++ b/NOVR/VrUi/HarmonyPatches/DynamicMapVrCursorPatch.cs
@@ -1,0 +1,259 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using HarmonyLib;
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+namespace NOVR.VrUi.HarmonyPatches;
+
+internal static class DynamicMapVrCursorPatch
+{
+    private const float MaxIconSelectDistanceSqr = 10000f;
+    private static readonly FieldInfo IconLookupField = AccessTools.Field(typeof(global::DynamicMap), "iconLookup");
+    private static int _lastRectangleMismatchLogFrame = -1000;
+
+    private static bool FixEnabled => ModConfiguration.Instance?.DynamicMapVrCursorFixEnabled.Value ?? true;
+    private static bool DiagnosticsEnabled => ModConfiguration.Instance?.DynamicMapVrCursorDiagnosticsEnabled.Value ?? true;
+
+    private static bool TryGetVrPointer(out Vector2 screenPoint)
+    {
+        screenPoint = default;
+        return FixEnabled && VrUiPointerState.TryGetScreenPoint(out screenPoint);
+    }
+
+    private static bool IsCursorInMapRectangle(global::DynamicMap map, Vector2 screenPoint)
+    {
+        if (map == null || map.mapBackground == null)
+        {
+            return false;
+        }
+
+        return RectTransformUtility.RectangleContainsScreenPoint(
+            map.mapBackground.rectTransform,
+            screenPoint,
+            VrUiPointerState.GetEventCamera());
+    }
+
+    private static bool TryGetMapLocalPoint(global::DynamicMap map, Vector2 screenPoint, out Vector2 localPoint)
+    {
+        localPoint = default;
+        if (map == null || map.mapImage == null)
+        {
+            return false;
+        }
+
+        var mapImageRect = map.mapImage.transform as RectTransform ?? map.mapImage.GetComponent<RectTransform>();
+        return mapImageRect != null &&
+               RectTransformUtility.ScreenPointToLocalPointInRectangle(
+                   mapImageRect,
+                   screenPoint,
+                   VrUiPointerState.GetEventCamera(),
+                   out localPoint);
+    }
+
+    private static bool TryFindRaycastMapIcon(Vector2 screenPoint, out MapIcon mapIcon)
+    {
+        mapIcon = null;
+        var eventSystem = EventSystem.current;
+        if (eventSystem == null)
+        {
+            return false;
+        }
+
+        var pointerEventData = new PointerEventData(eventSystem)
+        {
+            position = screenPoint
+        };
+
+        var results = new List<RaycastResult>();
+        eventSystem.RaycastAll(pointerEventData, results);
+        foreach (var result in results)
+        {
+            var candidate = result.gameObject.GetComponentInParent<MapIcon>();
+            if (IsSelectableMapIcon(candidate))
+            {
+                mapIcon = candidate;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryFindNearestUnitIcon(global::DynamicMap map, Vector2 screenPoint, out MapIcon mapIcon)
+    {
+        mapIcon = null;
+        if (IconLookupField.GetValue(map) is not Dictionary<Unit, UnitMapIcon> iconLookup)
+        {
+            return false;
+        }
+
+        var eventCamera = VrUiPointerState.GetEventCamera();
+        var bestDistance = MaxIconSelectDistanceSqr;
+        foreach (var icon in iconLookup.Values)
+        {
+            if (!IsSelectableMapIcon(icon))
+            {
+                continue;
+            }
+
+            var iconScreenPoint = eventCamera != null
+                ? RectTransformUtility.WorldToScreenPoint(eventCamera, icon.transform.position)
+                : (Vector2)icon.transform.position;
+            var distance = (screenPoint - iconScreenPoint).sqrMagnitude;
+            if (distance < bestDistance)
+            {
+                bestDistance = distance;
+                mapIcon = icon;
+            }
+        }
+
+        return mapIcon != null;
+    }
+
+    private static bool IsSelectableMapIcon(MapIcon mapIcon)
+    {
+        if (mapIcon == null ||
+            !mapIcon.gameObject.activeSelf ||
+            mapIcon.iconImage == null ||
+            !mapIcon.iconImage.raycastTarget)
+        {
+            return false;
+        }
+
+        if (mapIcon is UnitMapIcon unitMapIcon)
+        {
+            try
+            {
+                return unitMapIcon.unit != null &&
+                       !SceneSingleton<TargetListSelector>.i.CheckExclusions(unitMapIcon.unit);
+            }
+            catch (Exception)
+            {
+                return true;
+            }
+        }
+
+        return true;
+    }
+
+    private static void LogMapState(global::DynamicMap map, string reason, Vector2 vrPoint, MapIcon mapIcon = null)
+    {
+        if (!DiagnosticsEnabled)
+        {
+            return;
+        }
+
+        var realMouse = Input.mousePosition;
+        var vrContained = IsCursorInMapRectangle(map, vrPoint);
+        var realContained = map != null &&
+                            map.mapBackground != null &&
+                            RectTransformUtility.RectangleContainsScreenPoint(
+                                map.mapBackground.rectTransform,
+                                realMouse,
+                                null);
+        var hitName = mapIcon != null ? mapIcon.name : "<none>";
+        Debug.Log(
+            $"NOVR DynamicMap cursor: {reason}; vrPoint={vrPoint}; realMouse={realMouse}; " +
+            $"vrInMap={vrContained}; realInMap={realContained}; hit={hitName}; " +
+            $"screen={Screen.width}x{Screen.height}; pointerFrame={VrUiPointerState.LastUpdatedFrame}; frame={Time.frameCount}");
+    }
+
+    [HarmonyPatch(typeof(global::DynamicMap), nameof(global::DynamicMap.IsCursorInMapRectangle))]
+    private static class IsCursorInMapRectanglePatch
+    {
+        [HarmonyPrefix]
+        private static bool Prefix(global::DynamicMap __instance, ref bool __result)
+        {
+            if (!TryGetVrPointer(out var screenPoint))
+            {
+                return true;
+            }
+
+            __result = IsCursorInMapRectangle(__instance, screenPoint);
+            if (DiagnosticsEnabled)
+            {
+                var realResult = __instance != null &&
+                                 __instance.mapBackground != null &&
+                                 RectTransformUtility.RectangleContainsScreenPoint(
+                                     __instance.mapBackground.rectTransform,
+                                     Input.mousePosition,
+                                     null);
+                if (realResult != __result && Time.frameCount - _lastRectangleMismatchLogFrame > 30)
+                {
+                    _lastRectangleMismatchLogFrame = Time.frameCount;
+                    LogMapState(__instance, "rectangle mismatch", screenPoint);
+                }
+            }
+
+            return false;
+        }
+    }
+
+    [HarmonyPatch(typeof(global::DynamicMap), nameof(global::DynamicMap.GetCursorCoordinates))]
+    private static class GetCursorCoordinatesPatch
+    {
+        [HarmonyPrefix]
+        private static bool Prefix(global::DynamicMap __instance, ref GlobalPosition __result)
+        {
+            if (!TryGetVrPointer(out var screenPoint) ||
+                !TryGetMapLocalPoint(__instance, screenPoint, out var localPoint))
+            {
+                return true;
+            }
+
+            var mapMetersPerReferencePixel = __instance.mapDimension / 900f;
+            __result = new GlobalPosition(
+                localPoint.x * mapMetersPerReferencePixel,
+                0f,
+                localPoint.y * mapMetersPerReferencePixel);
+            return false;
+        }
+    }
+
+    [HarmonyPatch(typeof(global::DynamicMap), "SelectFromMap")]
+    private static class SelectFromMapPatch
+    {
+        [HarmonyPrefix]
+        private static bool Prefix(global::DynamicMap __instance)
+        {
+            if (!TryGetVrPointer(out var screenPoint))
+            {
+                return true;
+            }
+
+            if (!IsCursorInMapRectangle(__instance, screenPoint))
+            {
+                LogMapState(__instance, "select ignored outside map", screenPoint);
+                return false;
+            }
+
+            if (TryFindRaycastMapIcon(screenPoint, out var raycastIcon) ||
+                TryFindNearestUnitIcon(__instance, screenPoint, out raycastIcon))
+            {
+                LogMapState(__instance, "select clicked icon", screenPoint, raycastIcon);
+                raycastIcon.ClickIcon(MapIcon.ClickSource.Controller);
+                return false;
+            }
+
+            LogMapState(__instance, "select found no icon", screenPoint);
+            return false;
+        }
+    }
+
+    [HarmonyPatch(typeof(global::UnitMapIcon), nameof(global::UnitMapIcon.ClickIcon))]
+    private static class UnitMapIconClickDiagnosticsPatch
+    {
+        [HarmonyPrefix]
+        private static void Prefix(global::UnitMapIcon __instance, MapIcon.ClickSource clickSource)
+        {
+            if (!DiagnosticsEnabled || !VrUiPointerState.TryGetScreenPoint(out var screenPoint))
+            {
+                return;
+            }
+
+            LogMapState(SceneSingleton<DynamicMap>.i, $"unit click source={clickSource}", screenPoint, __instance);
+        }
+    }
+}

--- a/NOVR/VrUi/VrUiCursor.cs
+++ b/NOVR/VrUi/VrUiCursor.cs
@@ -45,6 +45,7 @@ public class VrUiCursor: NOVRBehaviour
     {
         if (!IsRealCursorVisible()) // This means we don't have to manually show and hide it every game update
         {
+            VrUiPointerState.SetInactive();
             if (_cursor != null)
             {
                 _cursor.SetActive(false);
@@ -60,10 +61,13 @@ public class VrUiCursor: NOVRBehaviour
         }
         if (_texture == null) return;
         UpdateCursorAngles();
+
+        var screenPoint = GetScreenPoint();
+        VrUiPointerState.SetActive(screenPoint, _realMouse.position.ReadValue());
         
         InputState.Change(_virtualMouse, new MouseState
         {
-            position = GetScreenPoint(),
+            position = screenPoint,
             buttons = _realMouse.leftButton.isPressed ? (ushort)1 : (ushort)0 
         });
         

--- a/NOVR/VrUi/VrUiCursor.cs
+++ b/NOVR/VrUi/VrUiCursor.cs
@@ -18,6 +18,7 @@ public class VrUiCursor: NOVRBehaviour
     private const int CursorTextureSize = 64;
     private const float CursorRingRadius = 12f;
     private const float CursorRingThickness = 4f;
+    private static readonly Vector2 CursorRectSize = new(CursorTextureSize, CursorTextureSize);
     private GameObject? _cursor;
     private RectTransform? _cursorRectTransform;
     private Canvas? _cursorCanvas;
@@ -100,9 +101,7 @@ public class VrUiCursor: NOVRBehaviour
         
         
         Vector3 direction = Quaternion.Euler(-cursorPitch, cursorYaw, 0f) * Vector3.forward;
-        var inScreenSpace = UiCamera.WorldToScreenPoint( direction * DefaultProjectionDistance);
-        var cursorDistance = GetDistanceUnderCursor(inScreenSpace);
-        Vector3 pos = direction * cursorDistance;
+        Vector3 pos = direction * DefaultProjectionDistance;
         _cursor.transform.position = pos;
         _cursor.transform.rotation = Quaternion.LookRotation(direction, Vector3.up);
     }
@@ -129,6 +128,11 @@ public class VrUiCursor: NOVRBehaviour
         _cursorCanvas.pixelPerfect = true;
 
         _cursorRectTransform = _cursor.GetComponent<RectTransform>();
+        _cursorRectTransform.anchorMin = new Vector2(0.5f, 0.5f);
+        _cursorRectTransform.anchorMax = new Vector2(0.5f, 0.5f);
+        _cursorRectTransform.pivot = new Vector2(0.5f, 0.5f);
+        _cursorRectTransform.anchoredPosition = Vector2.zero;
+        _cursorRectTransform.sizeDelta = CursorRectSize;
         _cursorImage = _cursor.AddComponent<RawImage>();
         _cursorImage.raycastTarget = false;
         _cursorImage.texture = _texture;
@@ -170,7 +174,9 @@ public class VrUiCursor: NOVRBehaviour
 
         foreach (var result in results)
         {
-            if (result.gameObject == _cursor || result.distance < 0f)
+            if (result.gameObject == _cursor ||
+                result.distance < 0f ||
+                result.gameObject.GetComponentInParent<global::MapIcon>() != null)
             {
                 continue;
             }

--- a/NOVR/VrUi/VrUiPointerState.cs
+++ b/NOVR/VrUi/VrUiPointerState.cs
@@ -1,0 +1,47 @@
+using System;
+using UnityEngine;
+
+namespace NOVR.VrUi;
+
+internal static class VrUiPointerState
+{
+    private const int FreshFrameWindow = 2;
+
+    public static bool Active { get; private set; }
+    public static Vector2 ScreenPoint { get; private set; }
+    public static Vector2 RealMousePoint { get; private set; }
+    public static int LastUpdatedFrame { get; private set; } = -1000;
+
+    public static bool HasFreshPointer => Active && Time.frameCount - LastUpdatedFrame <= FreshFrameWindow;
+
+    public static void SetActive(Vector2 screenPoint, Vector2 realMousePoint)
+    {
+        Active = true;
+        ScreenPoint = screenPoint;
+        RealMousePoint = realMousePoint;
+        LastUpdatedFrame = Time.frameCount;
+    }
+
+    public static void SetInactive()
+    {
+        Active = false;
+    }
+
+    public static bool TryGetScreenPoint(out Vector2 screenPoint)
+    {
+        screenPoint = ScreenPoint;
+        return HasFreshPointer;
+    }
+
+    public static Camera? GetEventCamera()
+    {
+        try
+        {
+            return APIBus.CockpitHudCamera;
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Use NOVR's VR cursor position for DynamicMap rectangle and coordinate hit tests instead of stale legacy mouse coordinates.
- Route controller-style map selection through the VR pointer so aircraft icons can be selected reliably in VR.
- Stabilize the rendered VR cursor so hover-resizing map icons and buttons do not make it jump away from the pointer.
- Add diagnostic logging for map cursor/select behavior while this fix is being validated.

## Tested
- Built `NOVR/NOVR.csproj` in Release on Windows.
- Installed the generated `NOVR.dll` into Nuclear Option's BepInEx plugin folder.
- Confirmed in VR that aircraft map selection works.
- Confirmed hovering small aircraft/heli/missile icons no longer makes the cursor jump.
- Confirmed the `Select Aircraft` button remains hoverable/clickable after the cursor stabilization.