### PR TITLE
Fix VR UI flicker during origin shifts

### DIFF
--- a/NOVR/VrCamera/VrCameraManager.cs
+++ b/NOVR/VrCamera/VrCameraManager.cs
@@ -25,7 +25,25 @@ public class VrCameraManager: MonoBehaviour
         foreach (var camera in cameras)
         {
             var gameObject = camera.gameObject;
-            if (gameObject.name is not (NuclearOptionMainCameraName or NuclearOptionMenuCameraName) || IgnoredCameras.Contains(camera)) continue;
+            if (gameObject.name is not (NuclearOptionMainCameraName or NuclearOptionMenuCameraName))
+            {
+                continue;
+            }
+
+            if (gameObject.name == NuclearOptionMainCameraName)
+            {
+                var existingTrackedCamera = GetTrackedMainCamera(gameObject);
+                if (existingTrackedCamera != null)
+                {
+                    EnsureTrackedMainCameraRig(camera, existingTrackedCamera);
+                    continue;
+                }
+            }
+
+            if (IgnoredCameras.Contains(camera))
+            {
+                continue;
+            }
 
             if (gameObject.name == NuclearOptionMainCameraName)
             {
@@ -53,8 +71,7 @@ public class VrCameraManager: MonoBehaviour
         var existingTrackedCamera = GetTrackedMainCamera(rootCamera.gameObject);
         if (existingTrackedCamera != null)
         {
-            IgnoredCameras.Add(rootCamera);
-            IgnoredCameras.Add(existingTrackedCamera);
+            EnsureTrackedMainCameraRig(rootCamera, existingTrackedCamera);
             return;
         }
 
@@ -89,6 +106,37 @@ public class VrCameraManager: MonoBehaviour
         ReparentTrackedChildren(rootCamera.transform, trackedCameraObject.transform);
 
         trackedCameraObject.AddComponent<VrCamera>();
+
+        IgnoredCameras.Add(rootCamera);
+        IgnoredCameras.Add(trackedCamera);
+    }
+
+    private static void EnsureTrackedMainCameraRig(Camera rootCamera, Camera trackedCamera)
+    {
+        if (rootCamera.enabled)
+        {
+            rootCamera.enabled = false;
+        }
+
+        if (rootCamera.CompareTag("MainCamera"))
+        {
+            rootCamera.tag = "Untagged";
+        }
+
+        if (!trackedCamera.enabled)
+        {
+            trackedCamera.enabled = true;
+        }
+
+        if (!trackedCamera.CompareTag("MainCamera"))
+        {
+            trackedCamera.tag = "MainCamera";
+        }
+
+        if (trackedCamera.GetComponent<VrCamera>() == null)
+        {
+            trackedCamera.gameObject.AddComponent<VrCamera>();
+        }
 
         IgnoredCameras.Add(rootCamera);
         IgnoredCameras.Add(trackedCamera);

--- a/NOVR/VrUi/HarmonyPatches/FloatingOriginUiRootPatch.cs
+++ b/NOVR/VrUi/HarmonyPatches/FloatingOriginUiRootPatch.cs
@@ -1,0 +1,59 @@
+using HarmonyLib;
+using NOVR.VrUi.SpecialBehavior;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace NOVR.VrUi.HarmonyPatches;
+
+internal static class FloatingOriginUiRootPatch
+{
+    private const float OriginShiftEpsilonSqr = 0.001f;
+
+    [HarmonyPatch(typeof(global::FloatingOrigin), nameof(global::FloatingOrigin.OriginShift))]
+    private static class OriginShiftPatch
+    {
+        [HarmonyPrefix]
+        private static void Prefix(out Vector3 __state)
+        {
+            __state = global::Datum.originPosition;
+        }
+
+        [HarmonyPostfix]
+        private static void Postfix(Vector3 __state)
+        {
+            if ((global::Datum.originPosition - __state).sqrMagnitude <= OriginShiftEpsilonSqr)
+            {
+                return;
+            }
+
+            StabilizePositionZeroUiRoots();
+        }
+
+        private static void StabilizePositionZeroUiRoots()
+        {
+            var activeScene = SceneManager.GetActiveScene();
+            foreach (var root in activeScene.GetRootGameObjects())
+            {
+                StabilizePositionZeroUiRoots(root.transform);
+            }
+        }
+
+        private static void StabilizePositionZeroUiRoots(Transform root)
+        {
+            if (root == null)
+            {
+                return;
+            }
+
+            if (root.GetComponent<PositionZeroBehavior>() != null)
+            {
+                root.position = Vector3.zero;
+            }
+
+            for (var i = 0; i < root.childCount; i++)
+            {
+                StabilizePositionZeroUiRoots(root.GetChild(i));
+            }
+        }
+    }
+}

--- a/NOVR/VrUi/NOUIManager.cs
+++ b/NOVR/VrUi/NOUIManager.cs
@@ -94,7 +94,17 @@ public class NOUIManager : NOVRBehaviour
 
     private void OnMainCameraChanged(Camera? previous, Camera? newCam)
     {
-        newCam?.gameObject?.GetComponent<UniversalAdditionalCameraData>()?.cameraStack?.Add(_cockpitHudCamera);
+        if (newCam == null)
+        {
+            return;
+        }
+
+        var cockpitHudCamera = CockpitHudCamera;
+        var cameraStack = newCam.gameObject.GetComponent<UniversalAdditionalCameraData>()?.cameraStack;
+        if (cameraStack != null && !cameraStack.Contains(cockpitHudCamera))
+        {
+            cameraStack.Add(cockpitHudCamera);
+        }
     }
 
     private void ConfigureUiCameras()


### PR DESCRIPTION
## Summary
- keep the tracked VR main camera rig stable if the game recreates or re-enables the root Main Camera
- avoid adding duplicate cockpit HUD overlay cameras to the URP camera stack
- stabilize NOVR UI roots immediately after the game's floating-origin shift so HUD/map canvases do not flicker for a frame

## Testing
- Built `NOVR/NOVR.csproj` in Release successfully.
- Installed and tested locally in Nuclear Option VR on the reporter's machine; the periodic HUD/map flicker during floating-origin shifts is fixed.

## Disclosure
This change was made with assistance from OpenAI Codex, a coding agent.