### PR TITLE
Reduce small per-frame VR overhead

### DIFF
--- a/NOVR/APIBus.cs
+++ b/NOVR/APIBus.cs
@@ -39,16 +39,19 @@ public class APIBus : MonoBehaviour
     
     public void Update()
     {
-        if (!CheckExtraDispatchers()) return;
+        CheckExtraDispatchers();
+    }
 
+    public static void SetMainCamera(Camera? newMainCamera)
+    {
+        if (newMainCamera == _previousMainCamera)
+        {
+            return;
+        }
 
-        var newMainCamera = Camera.main;                                                         
-        if (newMainCamera != _previousMainCamera)                                                
-        {                                                                                        
-            OnMainCameraChanged(_previousMainCamera, newMainCamera);                             
-            _previousMainCamera = newMainCamera;                                                 
-        }                                                                                        
-        
+        var previousMainCamera = _previousMainCamera;
+        _previousMainCamera = newMainCamera;
+        OnMainCameraChanged?.Invoke(previousMainCamera, newMainCamera);
     }
 
     /// <summary>

--- a/NOVR/VrCamera/VrCameraManager.cs
+++ b/NOVR/VrCamera/VrCameraManager.cs
@@ -5,6 +5,7 @@ using Il2CppInterop.Runtime.InteropTypes.Arrays;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Rendering.Universal;
+using UnityEngine.SceneManagement;
 
 namespace NOVR.VrCamera;
 
@@ -13,11 +14,49 @@ public class VrCameraManager: MonoBehaviour
     private const string NuclearOptionMainCameraName = "Main Camera";
     private const string NuclearOptionMenuCameraName = "Menu Camera";
     private const string VrCameraChildName = "NOVR Main Camera";
+    private const float CameraScanIntervalSeconds = 0.5f;
     private static readonly string[] TrackedChildNames = {"cockpitRenderer", "postProcessingRenderer"};
 
     public static HashSet<Camera> IgnoredCameras = new();
-    
-    private void Update() // Todo: Make me behave on events if possible
+
+    private bool _scanRequested = true;
+    private float _nextCameraScanTime;
+
+    private void OnEnable()
+    {
+        SceneManager.sceneLoaded += OnSceneLoaded;
+        RequestCameraScan();
+    }
+
+    private void OnDisable()
+    {
+        SceneManager.sceneLoaded -= OnSceneLoaded;
+    }
+
+    private void Update()
+    {
+        if (!_scanRequested && Time.unscaledTime < _nextCameraScanTime)
+        {
+            return;
+        }
+
+        _scanRequested = false;
+        _nextCameraScanTime = Time.unscaledTime + CameraScanIntervalSeconds;
+        ScanCameras();
+    }
+
+    private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
+    {
+        RequestCameraScan();
+    }
+
+    private void RequestCameraScan()
+    {
+        _scanRequested = true;
+        _nextCameraScanTime = 0f;
+    }
+
+    private void ScanCameras()
     {
         Camera[] cameras = new Camera[Camera.allCamerasCount];
         Camera.GetAllCameras(cameras);
@@ -55,6 +94,7 @@ public class VrCameraManager: MonoBehaviour
         {
             IgnoredCameras.Add(rootCamera);
             IgnoredCameras.Add(existingTrackedCamera);
+            APIBus.SetMainCamera(existingTrackedCamera);
             return;
         }
 
@@ -92,6 +132,7 @@ public class VrCameraManager: MonoBehaviour
 
         IgnoredCameras.Add(rootCamera);
         IgnoredCameras.Add(trackedCamera);
+        APIBus.SetMainCamera(trackedCamera);
     }
 
     private void HandleChildCameras(Camera parentCamera)

--- a/NOVR/VrUi/NOUIManager.cs
+++ b/NOVR/VrUi/NOUIManager.cs
@@ -45,6 +45,7 @@ public class NOUIManager : NOVRBehaviour
         UIBehaviorPatcher.DoPatching();
         Create<VrUiCursor>(transform);
         ConfigureUiCameras();
+        OnMainCameraChanged(null, APIBus.MainCamera);
     }
 
     protected override void OnSettingChanged()
@@ -55,7 +56,6 @@ public class NOUIManager : NOVRBehaviour
 
     private void Update()
     {
-        ConfigureUiCameras();
         UpdateSmoothedPosition();
     }
     
@@ -94,7 +94,17 @@ public class NOUIManager : NOVRBehaviour
 
     private void OnMainCameraChanged(Camera? previous, Camera? newCam)
     {
-        newCam?.gameObject?.GetComponent<UniversalAdditionalCameraData>()?.cameraStack?.Add(_cockpitHudCamera);
+        if (newCam == null)
+        {
+            return;
+        }
+
+        var cockpitHudCamera = CockpitHudCamera;
+        var cameraStack = newCam.gameObject.GetComponent<UniversalAdditionalCameraData>()?.cameraStack;
+        if (cameraStack != null && !cameraStack.Contains(cockpitHudCamera))
+        {
+            cameraStack.Add(cockpitHudCamera);
+        }
     }
 
     private void ConfigureUiCameras()


### PR DESCRIPTION
## Summary
- make camera discovery a small periodic/scene-load scan instead of scanning every frame
- publish main camera changes from the VR camera manager instead of polling `Camera.main` every frame
- configure the NOVR UI camera at startup/settings changes instead of rewriting the same camera constants every frame
- avoid adding duplicate cockpit HUD overlay cameras to the URP camera stack

These are minor hygiene/performance improvements only. This branch is based directly on upstream `main` and intentionally does not include the floating-origin flicker fix, OpenXR single-pass changes, or render-scale changes.

## Testing
- Built `NOVR/NOVR.csproj` in Release successfully.
- The same hygiene behavior was also tested locally in Nuclear Option VR on the reporter's machine together with the separately submitted flicker fix; main menu, aircraft selection, cockpit HUD, map, and floating-origin flicker behavior still worked there.

## Disclosure
This change was made with assistance from OpenAI Codex, a coding agent.