### PR TITLE
Fix map overlay raycast blocking

### DIFF
--- a/NOVR/VrUi/HarmonyPatches/DynamicMapRadarVisualizationRotationSafePatch.cs
+++ b/NOVR/VrUi/HarmonyPatches/DynamicMapRadarVisualizationRotationSafePatch.cs
@@ -51,6 +51,7 @@ internal static class DynamicMapRadarVisualizationRotationSafePatch
             var iconLayer = dynamicMap.iconLayer.transform;
             var emitterMapPosition = emitter.GlobalPosition().AsVector3() * dynamicMap.mapDisplayFactor;
             var emitterLocalPosition = new Vector3(emitterMapPosition.x, emitterMapPosition.z, 0.0f);
+            vectorImage.raycastTarget = false;
             vectorImage.transform.localPosition = emitterLocalPosition;
 
             if (DynamicMap.TryGetMapIcon(combatHud.aircraft, out var aircraftIcon))

--- a/NOVR/VrUi/HarmonyPatches/JammedMarkerRotationSafePatch.cs
+++ b/NOVR/VrUi/HarmonyPatches/JammedMarkerRotationSafePatch.cs
@@ -48,13 +48,23 @@ internal static class JammedMarkerRotationSafePatch
             var jammerLocalPosition = iconLayer.InverseTransformPoint(jammedByIcon.transform.position);
             var localDelta = jammerLocalPosition - jammedLocalPosition;
             vectorLineImage.enabled = true;
+            vectorLineImage.raycastTarget = false;
             vectorLine.transform.localPosition = jammedLocalPosition;
             vectorLine.transform.localEulerAngles = new Vector3(
                 0.0f,
                 0.0f,
                 -Mathf.Atan2(localDelta.x, localDelta.y) * Mathf.Rad2Deg);
             vectorLine.transform.localScale = new Vector3(1.0f, localDelta.magnitude, 1.0f);
+            DisableRaycasts(vectorLine.transform);
             return false;
+        }
+    }
+
+    private static void DisableRaycasts(Transform root)
+    {
+        foreach (var graphic in root.GetComponentsInChildren<Graphic>(true))
+        {
+            graphic.raycastTarget = false;
         }
     }
 }

--- a/NOVR/VrUi/HarmonyPatches/ThreatItemVectorLineRotationSafePatch.cs
+++ b/NOVR/VrUi/HarmonyPatches/ThreatItemVectorLineRotationSafePatch.cs
@@ -34,7 +34,16 @@ internal static class ThreatItemVectorLineRotationSafePatch
                 0.0f,
                 -Mathf.Atan2(localDelta.x, localDelta.y) * Mathf.Rad2Deg);
             vectorLine.transform.localScale = (Vector3.one + Vector3.up * localDelta.magnitude) / iconLayer.lossyScale.x;
+            DisableRaycasts(vectorLine.transform);
             return false;
+        }
+    }
+
+    private static void DisableRaycasts(Transform root)
+    {
+        foreach (var graphic in root.GetComponentsInChildren<UnityEngine.UI.Graphic>(true))
+        {
+            graphic.raycastTarget = false;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Prevent non-interactive dynamic map overlay graphics from receiving UI raycasts.
- Keeps radar ping vectors, jammer vectors, and threat vector lines visible while allowing map icons/buttons underneath to remain clickable in VR.

## Testing
- Built `NOVR/NOVR.csproj` in Release with the local .NET SDK. Build passes with existing warnings.

## Disclosure
This change was prepared with assistance from a coding agent.