### PR TITLE
Feature/3D menu environment scene

### DIFF
--- a/NOVR/Core.cs
+++ b/NOVR/Core.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using NOVR.VrCamera;
 using NOVR.VrTogglers;
 using NOVR.VrUi;
+using NOVR.VrUi.Native;
 using UnityEngine;
 using UnityEngine.InputSystem.XR;
 using UnityEngine.SceneManagement;
@@ -36,6 +37,7 @@ public class Core : MonoBehaviour
         DontDestroyOnLoad(gameObject);
         gameObject.AddComponent<VrCameraManager>();
         gameObject.AddComponent<APIBus>();
+        EnsureNativeMenuEnvironmentAssetCache();
     }
 
     private static void HandleApplicationQuitting()
@@ -59,7 +61,7 @@ public class Core : MonoBehaviour
 
     private void Start()
     {
-        
+        EnsureNativeMenuEnvironmentAssetCache();
         
         var xrDeviceType = Type.GetType("UnityEngine.XR.XRDevice, UnityEngine.XRModule") ??
                            Type.GetType("UnityEngine.XR.XRDevice, UnityEngine.VRModule") ??
@@ -85,7 +87,19 @@ public class Core : MonoBehaviour
 
     private void Update()
     {
+        EnsureNativeMenuEnvironmentAssetCache();
         UpdatePhysicsRate();
+    }
+
+    private void EnsureNativeMenuEnvironmentAssetCache()
+    {
+        if (NativeMenuEnvironmentAssetCache.Instance != null ||
+            gameObject.GetComponent<NativeMenuEnvironmentAssetCache>() != null)
+        {
+            return;
+        }
+
+        gameObject.AddComponent<NativeMenuEnvironmentAssetCache>();
     }
 
     private void UpdatePhysicsRate()

--- a/NOVR/VrUi/Native/MenuEnvironmentHangarDoorAnimator.cs
+++ b/NOVR/VrUi/Native/MenuEnvironmentHangarDoorAnimator.cs
@@ -1,0 +1,77 @@
+using UnityEngine;
+
+namespace NOVR.VrUi.Native;
+
+public sealed class MenuEnvironmentHangarDoorAnimator : MonoBehaviour
+{
+    private Vector3 _closedLocalPosition;
+    private Quaternion _closedLocalRotation;
+    private Vector3 _openLocalOffset;
+    private float _openDelaySeconds;
+    private float _openDurationSeconds = 1f;
+    private float _elapsedSeconds;
+    private bool _hasClosedTransform;
+    private bool _complete;
+
+    public void Configure(Vector3 openLocalOffset, float openDelaySeconds, float openDurationSeconds)
+    {
+        if (!_hasClosedTransform)
+        {
+            CaptureClosedTransform();
+        }
+
+        _openLocalOffset = openLocalOffset;
+        _openDelaySeconds = Mathf.Max(0f, openDelaySeconds);
+        _openDurationSeconds = Mathf.Max(0.01f, openDurationSeconds);
+        Restart();
+    }
+
+    private void Awake()
+    {
+        CaptureClosedTransform();
+    }
+
+    private void OnEnable()
+    {
+        Restart();
+    }
+
+    private void Update()
+    {
+        if (_complete) return;
+
+        _elapsedSeconds += Time.deltaTime;
+
+        var openTime = _elapsedSeconds - _openDelaySeconds;
+        var openAmount = Mathf.Clamp01(openTime / _openDurationSeconds);
+        var easedOpenAmount = openAmount * openAmount * (3f - 2f * openAmount);
+
+        transform.localPosition = Vector3.Lerp(_closedLocalPosition, _closedLocalPosition + _openLocalOffset, easedOpenAmount);
+        transform.localRotation = _closedLocalRotation;
+
+        if (openAmount >= 1f)
+        {
+            _complete = true;
+        }
+    }
+
+    private void CaptureClosedTransform()
+    {
+        _closedLocalPosition = transform.localPosition;
+        _closedLocalRotation = transform.localRotation;
+        _hasClosedTransform = true;
+    }
+
+    private void Restart()
+    {
+        if (!_hasClosedTransform)
+        {
+            CaptureClosedTransform();
+        }
+
+        _elapsedSeconds = 0f;
+        _complete = false;
+        transform.localPosition = _closedLocalPosition;
+        transform.localRotation = _closedLocalRotation;
+    }
+}

--- a/NOVR/VrUi/Native/NativeMenuEnvironment.cs
+++ b/NOVR/VrUi/Native/NativeMenuEnvironment.cs
@@ -17,19 +17,37 @@ public sealed class NativeMenuEnvironment : MonoBehaviour
     private const string VisualRootName = "Visuals";
     private const string PreviewUnitName = "AttackHelo1";
     private const string PreviewShipName = "Frigate1";
-    private const string NavLightStarburstTextureName = "starburst";
     private const string SimpleWaterPlaneName = "NOVR Menu Environment Water Plane";
+    private const string CloudPlaneName = "cloudPlane";
+    private const string MenuCloudPlaneName = "NOVR Menu Environment Cloud Plane";
+    private const string ShipWakeRootName = "wakefoam";
+    private const string ShipHangarDoorName = "frigate1_hangarDoor";
     private const string MenuCameraName = "Menu Camera";
     private const string DefaultSkyboxMaterialName = "Default-Skybox";
     private const string EncyclopediaSceneName = "Encyclopedia";
     private const float EnvironmentCameraFarClipPlane = 80000f;
     private const float MenuEnvironmentFogDensity = 0.00105f;
+    private const float ShipWakeFlowSpeed = 40f;
+    private const float ShipHangarDoorOpenDelaySeconds = 3.0f;
+    private const float ShipHangarDoorOpenDurationSeconds = 4.0f;
     private static readonly Vector3 MenuEnvironmentWorldAnchor = new(-23.8808f, 2.774f, -821.3446f);
     private static readonly Vector3 SimpleWaterPlaneLocalPosition = new(0f, -10f, -9.66f);
     private static readonly Vector3 SimpleWaterPlaneLocalScale = new(9000f, 1f, 9000f);
+    private static readonly Vector3 CloudPlaneLocalPosition = new(0f, 500f, 0f);
+    private static readonly Vector3 CloudPlaneLocalScale = new(1f, 10f, 1f);
+    private static readonly Vector3 ShipHangarDoorOpenLocalOffset = new(0f, 5f, 2f);
     private static readonly Color MenuEnvironmentFogColor = new(0.52f, 0.68f, 0.80f, 1f);
+    private static readonly Color CloudMaterialColor = new(3.75f, 3.78f, 1.72f, 0.98f);
+    private static readonly Color CloudLayerParticleColor = new(1f, 1f, 1f, 0.5f);
+    private static readonly Color DistantCloudParticleColor = Color.white;
     private static readonly Color SimpleWaterBaseColor = new(0.12f, 0.32f, 0.42f, 1f);
     private static readonly Color SimpleWaterHighlightColor = new(0.28f, 0.58f, 0.70f, 1f);
+    private static readonly HashSet<string> HiddenShipPreviewChildNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "frigate1_hull_port",
+        "frigate1_hull_starboard",
+        "frigate1_hull_F",
+    };
     private static readonly Vector3 ShipHangarSourceAnchor = new(0f, 3.8098f, -22.1115f);
     private static readonly Vector3 ShipHangarTargetAnchor = new(0f, 1.25f, 0.45f);
     private static readonly Vector3 PreviewLocalOffset = new(23.8808f, -2.774f, 821.3446f);
@@ -76,6 +94,7 @@ public sealed class NativeMenuEnvironment : MonoBehaviour
     private GameObject? _shipRoot;
     private GameObject? _previewUnit;
     private GameObject? _waterPlane;
+    private GameObject? _cloudPlane;
     private Material? _waterMaterial;
     private Texture2D? _waterTexture;
     private Camera? _environmentCamera;
@@ -93,6 +112,7 @@ public sealed class NativeMenuEnvironment : MonoBehaviour
     private RenderSettingsSnapshot _originalRenderSettings;
     private bool _renderSettingsCaptured;
     private bool _spawnAttempted;
+    private bool _loggedWarmupDelay;
 
     private struct RenderSettingsSnapshot
     {
@@ -121,6 +141,21 @@ public sealed class NativeMenuEnvironment : MonoBehaviour
             return;
         }
 
+        var assetCache = NativeMenuEnvironmentAssetCache.Instance;
+        assetCache?.EnsureMenuWarmupStarted();
+        if (assetCache?.ShouldDelayMenuEnvironment == true)
+        {
+            if (!_loggedWarmupDelay)
+            {
+                Debug.Log("[NOVR] Native menu environment waiting for hidden Encyclopedia asset warmup.");
+                _loggedWarmupDelay = true;
+            }
+
+            return;
+        }
+
+        _loggedWarmupDelay = false;
+
         if (!EnsureEnvironmentScene())
         {
             return;
@@ -129,13 +164,13 @@ public sealed class NativeMenuEnvironment : MonoBehaviour
         EnsureRoot();
         PlaceRoot(menuTransform);
         EnsureSimpleWaterPlane();
+        EnsureCloudPlane();
         ApplyEnvironmentRenderSettings();
         ApplyEnvironmentCameraSettings();
         EnsurePreviewScene();
         SetVisible(true);
         ApplyShipVisualOverrides();
         ApplyAircraftVisualOverrides();
-        RestorePreviewEffectObjects();
     }
 
     private void OnEnable()
@@ -208,6 +243,13 @@ public sealed class NativeMenuEnvironment : MonoBehaviour
     {
         if (!string.Equals(scene.name, EnvironmentSceneName, StringComparison.OrdinalIgnoreCase)) return;
 
+        if (_environmentRoot != null)
+        {
+            _environmentScene = default;
+            Debug.Log($"[NOVR] Native menu environment preserved root after scene '{EnvironmentSceneName}' unloaded during menu scene transition.");
+            return;
+        }
+
         ClearEnvironmentSceneObjectReferences();
         ResetSceneScopedRenderingState();
         _environmentScene = default;
@@ -216,6 +258,11 @@ public sealed class NativeMenuEnvironment : MonoBehaviour
 
     private bool EnsureEnvironmentScene()
     {
+        if (_environmentRoot != null)
+        {
+            return true;
+        }
+
         if (_environmentScene.IsValid() && _environmentScene.isLoaded)
         {
             ResetSceneObjectReferencesIfDestroyed();
@@ -281,6 +328,7 @@ public sealed class NativeMenuEnvironment : MonoBehaviour
         _shipRoot = null;
         _previewUnit = null;
         _waterPlane = null;
+        _cloudPlane = null;
         _spawnAttempted = false;
     }
 
@@ -316,6 +364,8 @@ public sealed class NativeMenuEnvironment : MonoBehaviour
         {
             SceneManager.MoveGameObjectToScene(_environmentRoot, _environmentScene);
         }
+
+        DontDestroyOnLoad(_environmentRoot);
 
         var visualRoot = new GameObject(VisualRootName);
         visualRoot.transform.SetParent(_environmentRoot.transform, false);
@@ -363,9 +413,47 @@ public sealed class NativeMenuEnvironment : MonoBehaviour
         Debug.Log("[NOVR] Native menu environment created simple water plane.");
     }
 
+    private void EnsureCloudPlane()
+    {
+        if (_visualRoot == null || _cloudPlane != null) return;
+
+        if (NativeMenuEnvironmentAssetCache.Instance?.TryCreateCloudPlane(out var cloudPlane) != true ||
+            cloudPlane == null)
+        {
+            return;
+        }
+
+        _cloudPlane = cloudPlane;
+        _cloudPlane.name = MenuCloudPlaneName;
+        _cloudPlane.SetActive(false);
+        _cloudPlane.transform.SetParent(_visualRoot, false);
+        _cloudPlane.transform.localPosition = CloudPlaneLocalPosition;
+        _cloudPlane.transform.localRotation = Quaternion.identity;
+        _cloudPlane.transform.localScale = CloudPlaneLocalScale;
+
+        PrepareCloudPlane(_cloudPlane);
+        if (_cloudPlane.GetComponent<MenuEnvironmentCloudWind>() == null)
+        {
+            _cloudPlane.AddComponent<MenuEnvironmentCloudWind>();
+        }
+
+        _cloudPlane.SetActive(true);
+        PrepareCloudPlane(_cloudPlane);
+
+        Debug.Log("[NOVR] Native menu environment cloned cached Encyclopedia cloud plane.");
+    }
+
     private Material? CreateSimpleWaterMaterial()
     {
         if (_waterMaterial != null) return _waterMaterial;
+
+        if (NativeMenuEnvironmentAssetCache.Instance?.TryCreateWaterMaterial(out var cachedWaterMaterial) == true &&
+            cachedWaterMaterial != null)
+        {
+            _waterMaterial = cachedWaterMaterial;
+            Debug.Log("[NOVR] Native menu environment using cached Encyclopedia water material.");
+            return cachedWaterMaterial;
+        }
 
         var shader = Shader.Find("Universal Render Pipeline/Lit") ??
                      Shader.Find("Universal Render Pipeline/Unlit") ??
@@ -483,6 +571,231 @@ public sealed class NativeMenuEnvironment : MonoBehaviour
         }
     }
 
+    private static void PrepareCloudPlane(GameObject root)
+    {
+        StripCloudPlaneGameplayComponents(root);
+        LayerHelper.SetLayerRecursive(root.transform, LayerHelper.GetVrUiLayer());
+        SetMatchingChildrenActive(root.transform, static transform => string.Equals(transform.name, "lightning", StringComparison.OrdinalIgnoreCase), false);
+        ApplyCloudMaterialOverrides(root);
+        ApplyCloudParticleOverrides(root);
+
+        var renderers = root.GetComponentsInChildren<Renderer>(true);
+        for (var index = 0; index < renderers.Length; index++)
+        {
+            var renderer = renderers[index];
+            if (renderer == null) continue;
+
+            renderer.enabled = true;
+            renderer.forceRenderingOff = false;
+            renderer.shadowCastingMode = ShadowCastingMode.Off;
+            renderer.receiveShadows = false;
+        }
+
+        var particleSystems = root.GetComponentsInChildren<ParticleSystem>(true);
+        for (var index = 0; index < particleSystems.Length; index++)
+        {
+            var particleSystem = particleSystems[index];
+            if (particleSystem == null ||
+                !particleSystem.gameObject.activeInHierarchy ||
+                ShouldKeepCloudParticleSystemStopped(particleSystem))
+            {
+                continue;
+            }
+
+            particleSystem.Play(true);
+        }
+    }
+
+    private static void ApplyCloudParticleOverrides(GameObject root)
+    {
+        var particleSystems = root.GetComponentsInChildren<ParticleSystem>(true);
+        for (var index = 0; index < particleSystems.Length; index++)
+        {
+            var particleSystem = particleSystems[index];
+            if (particleSystem == null) continue;
+
+            if (IsCloudPlaneParticleSystem(root, particleSystem))
+            {
+                ConfigureCloudLayerParticles(particleSystem);
+                continue;
+            }
+
+            if (string.Equals(particleSystem.gameObject.name, "distantClouds", StringComparison.OrdinalIgnoreCase))
+            {
+                ConfigureDistantCloudParticles(particleSystem);
+                continue;
+            }
+
+            if (ShouldKeepCloudParticleSystemStopped(particleSystem))
+            {
+                particleSystem.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
+                particleSystem.gameObject.SetActive(false);
+            }
+        }
+    }
+
+    private static bool IsCloudPlaneParticleSystem(GameObject root, ParticleSystem particleSystem)
+    {
+        return particleSystem.gameObject == root ||
+               string.Equals(particleSystem.gameObject.name, CloudPlaneName, StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(particleSystem.gameObject.name, MenuCloudPlaneName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool ShouldKeepCloudParticleSystemStopped(ParticleSystem particleSystem)
+    {
+        var name = particleSystem.gameObject.name;
+        return name.IndexOf("flyThrough", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               string.Equals(name, "lightning", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static void ConfigureCloudLayerParticles(ParticleSystem particleSystem)
+    {
+        var main = particleSystem.main;
+        main.duration = 1f;
+        main.loop = false;
+        main.prewarm = false;
+        main.startDelay = new ParticleSystem.MinMaxCurve(0f);
+        main.startLifetime = new ParticleSystem.MinMaxCurve(15.00058f);
+        main.startSpeed = new ParticleSystem.MinMaxCurve(0f);
+        main.startSize = new ParticleSystem.MinMaxCurve(479.8216f);
+        main.startRotation = new ParticleSystem.MinMaxCurve(0f);
+        main.startColor = new ParticleSystem.MinMaxGradient(CloudLayerParticleColor);
+        main.maxParticles = 3000;
+
+        var emission = particleSystem.emission;
+        emission.enabled = false;
+        emission.rateOverTime = new ParticleSystem.MinMaxCurve(1f);
+
+        var shape = particleSystem.shape;
+        shape.enabled = false;
+        shape.shapeType = ParticleSystemShapeType.Cone;
+        shape.radius = 1f;
+        shape.angle = 25f;
+        shape.arc = 360f;
+        shape.scale = Vector3.one;
+        shape.position = Vector3.zero;
+        shape.rotation = Vector3.zero;
+    }
+
+    private static void ConfigureDistantCloudParticles(ParticleSystem particleSystem)
+    {
+        var main = particleSystem.main;
+        main.duration = 20f;
+        main.loop = true;
+        main.prewarm = false;
+        main.startDelay = new ParticleSystem.MinMaxCurve(0f);
+        main.startLifetime = new ParticleSystem.MinMaxCurve(20f);
+        main.startSpeed = new ParticleSystem.MinMaxCurve(5f);
+        main.startSize = new ParticleSystem.MinMaxCurve(540f, 810f);
+        main.startRotation = new ParticleSystem.MinMaxCurve(0f);
+        main.startColor = new ParticleSystem.MinMaxGradient(DistantCloudParticleColor);
+        main.maxParticles = 300;
+
+        var emission = particleSystem.emission;
+        emission.enabled = true;
+        emission.rateOverTime = new ParticleSystem.MinMaxCurve(25f);
+
+        var shape = particleSystem.shape;
+        shape.enabled = true;
+        shape.shapeType = ParticleSystemShapeType.Circle;
+        shape.radius = 40000f;
+        shape.angle = 25f;
+        shape.arc = 360f;
+        shape.scale = Vector3.one;
+        shape.position = Vector3.zero;
+        shape.rotation = new Vector3(90f, 0f, 0f);
+    }
+
+    private static void ApplyCloudMaterialOverrides(GameObject root)
+    {
+        var renderers = root.GetComponentsInChildren<Renderer>(true);
+        for (var rendererIndex = 0; rendererIndex < renderers.Length; rendererIndex++)
+        {
+            var renderer = renderers[rendererIndex];
+            if (renderer == null) continue;
+
+            var materials = renderer.sharedMaterials;
+            var changed = false;
+
+            for (var materialIndex = 0; materialIndex < materials.Length; materialIndex++)
+            {
+                var material = materials[materialIndex];
+                if (material == null || !IsCloudMaterial(renderer, material)) continue;
+
+                if (!material.name.EndsWith(" NOVR", StringComparison.Ordinal))
+                {
+                    material = new Material(material)
+                    {
+                        name = $"{material.name} NOVR"
+                    };
+                    materials[materialIndex] = material;
+                    changed = true;
+                }
+
+                SetCloudMaterialColor(material);
+            }
+
+            if (changed)
+            {
+                renderer.sharedMaterials = materials;
+            }
+        }
+    }
+
+    private static bool IsCloudMaterial(Renderer renderer, Material material)
+    {
+        return ContainsCloudToken(renderer.gameObject.name) ||
+               ContainsCloudToken(material.name) ||
+               (material.shader != null && ContainsCloudToken(material.shader.name));
+    }
+
+    private static bool ContainsCloudToken(string value)
+    {
+        return value.IndexOf("cloud", StringComparison.OrdinalIgnoreCase) >= 0;
+    }
+
+    private static void SetCloudMaterialColor(Material material)
+    {
+        if (material.HasProperty("_CloudColor"))
+        {
+            material.SetColor("_CloudColor", CloudMaterialColor);
+        }
+
+        if (material.HasProperty("_BaseColor"))
+        {
+            material.SetColor("_BaseColor", CloudMaterialColor);
+        }
+
+        if (material.HasProperty("_Color"))
+        {
+            material.SetColor("_Color", CloudMaterialColor);
+        }
+    }
+
+    private static int StripCloudPlaneGameplayComponents(GameObject root)
+    {
+        var stripped = 0;
+        var components = root.GetComponentsInChildren<MonoBehaviour>(true);
+
+        for (var index = 0; index < components.Length; index++)
+        {
+            var component = components[index];
+            if (component == null) continue;
+
+            if (!string.Equals(component.GetType().Name, "CloudLayer", StringComparison.Ordinal)) continue;
+
+            Object.DestroyImmediate(component);
+            stripped++;
+        }
+
+        if (stripped > 0)
+        {
+            Debug.Log($"[NOVR] Native menu environment stripped {stripped} cloud gameplay component(s) from '{GetTransformPath(root.transform)}'.");
+        }
+
+        return stripped;
+    }
+
     private void PlaceRoot(Transform menuTransform)
     {
         if (_environmentRoot == null) return;
@@ -514,6 +827,7 @@ public sealed class NativeMenuEnvironment : MonoBehaviour
             ApplyShipVisualOverrides();
             _shipRoot.SetActive(true);
             ApplyShipVisualOverrides();
+            ApplyShipWakeTuning();
 
             Debug.Log($"[NOVR] Native menu environment spawned preview ship prefab '{shipPrefab.name}' from Encyclopedia.");
         }
@@ -539,7 +853,6 @@ public sealed class NativeMenuEnvironment : MonoBehaviour
         PreparePreviewObject(_previewUnit);
         _previewUnit.SetActive(true);
         ApplyAircraftVisualOverrides();
-        RestorePreviewEffectObjects();
 
         Debug.Log($"[NOVR] Native menu environment spawned preview aircraft prefab '{aircraftPrefab.name}' from Encyclopedia.");
     }
@@ -790,20 +1103,137 @@ public sealed class NativeMenuEnvironment : MonoBehaviour
                fullName.StartsWith("Mirage.", StringComparison.Ordinal);
     }
 
-    private void RestorePreviewEffectObjects()
-    {
-        if (_previewUnit == null) return;
-
-        RestorePreviewEffectObject(_previewUnit, "navlight_effects_L");
-        RestorePreviewEffectObject(_previewUnit, "navlight_effects_R");
-        HideNavLightStarburstRenderers(_previewUnit);
-    }
-
     private void ApplyShipVisualOverrides()
     {
         if (_shipRoot == null) return;
 
         SetMatchingChildrenActive(_shipRoot.transform, IsShipPreviewHiddenChild, false);
+        EnsureShipHangarDoorAnimator();
+    }
+
+    private void EnsureShipHangarDoorAnimator()
+    {
+        if (_shipRoot == null) return;
+
+        var door = FindChildByName(_shipRoot.transform, ShipHangarDoorName);
+        if (door == null) return;
+
+        if (!door.gameObject.activeSelf)
+        {
+            door.gameObject.SetActive(true);
+        }
+
+        var renderers = door.GetComponentsInChildren<Renderer>(true);
+        for (var index = 0; index < renderers.Length; index++)
+        {
+            var renderer = renderers[index];
+            if (renderer == null) continue;
+
+            renderer.gameObject.SetActive(true);
+            renderer.enabled = true;
+            renderer.forceRenderingOff = false;
+        }
+
+        if (door.GetComponent<MenuEnvironmentHangarDoorAnimator>() != null) return;
+
+        door.gameObject
+            .AddComponent<MenuEnvironmentHangarDoorAnimator>()
+            .Configure(ShipHangarDoorOpenLocalOffset, ShipHangarDoorOpenDelaySeconds, ShipHangarDoorOpenDurationSeconds);
+    }
+
+    private void ApplyShipWakeTuning()
+    {
+        if (_shipRoot == null) return;
+
+        var wakeRoot = FindChildByName(_shipRoot.transform, ShipWakeRootName);
+        if (wakeRoot == null)
+        {
+            Debug.LogWarning("[NOVR] Native menu environment could not find preview ship wake effect root.");
+            return;
+        }
+
+        if (!wakeRoot.gameObject.activeSelf)
+        {
+            wakeRoot.gameObject.SetActive(true);
+        }
+
+        var flow = -_shipRoot.transform.forward * ShipWakeFlowSpeed;
+        var tunedParticles = 0;
+        var particleSystems = wakeRoot.GetComponentsInChildren<ParticleSystem>(true);
+        for (var index = 0; index < particleSystems.Length; index++)
+        {
+            var particleSystem = particleSystems[index];
+            if (particleSystem == null) continue;
+
+            if (!particleSystem.gameObject.activeSelf)
+            {
+                particleSystem.gameObject.SetActive(true);
+            }
+
+            ApplyShipWakeFlow(particleSystem, flow);
+            ApplyShipWakeParticleTuning(particleSystem);
+            particleSystem.Clear(true);
+            particleSystem.Play(true);
+            tunedParticles++;
+        }
+
+        Debug.Log($"[NOVR] Native menu environment tuned preview ship wake particles: count={tunedParticles}, flow={flow}.");
+    }
+
+    private static void ApplyShipWakeFlow(ParticleSystem particleSystem, Vector3 flow)
+    {
+        var inherit = particleSystem.inheritVelocity;
+        inherit.enabled = false;
+
+        var velocity = particleSystem.velocityOverLifetime;
+        velocity.enabled = true;
+        velocity.space = ParticleSystemSimulationSpace.World;
+        velocity.x = new ParticleSystem.MinMaxCurve(flow.x);
+        velocity.y = new ParticleSystem.MinMaxCurve(flow.y);
+        velocity.z = new ParticleSystem.MinMaxCurve(flow.z);
+
+        var limit = particleSystem.limitVelocityOverLifetime;
+        limit.enabled = false;
+    }
+
+    private static void ApplyShipWakeParticleTuning(ParticleSystem particleSystem)
+    {
+        var name = particleSystem.gameObject.name;
+        var main = particleSystem.main;
+        var emission = particleSystem.emission;
+
+        if (string.Equals(name, "wakefoam", StringComparison.Ordinal))
+        {
+            emission.rateOverTimeMultiplier = 18f;
+            main.startSizeMultiplier = 170f;
+            main.startLifetimeMultiplier = 255f;
+            main.maxParticles = 900;
+        }
+        else if (string.Equals(name, "bowFoam", StringComparison.Ordinal))
+        {
+            emission.rateOverTimeMultiplier = 0.5f;
+            main.startSizeMultiplier = 520f;
+            main.startLifetimeMultiplier = 8f;
+            main.maxParticles = 250;
+        }
+        else if (string.Equals(name, "thrusterSprayR", StringComparison.Ordinal))
+        {
+            emission.rateOverTimeMultiplier = 1f;
+            main.startSizeMultiplier = 4f;
+            main.startSpeedMultiplier = 28f;
+            main.startLifetimeMultiplier = 0.55f;
+            main.maxParticles = 35;
+            main.startColor = new ParticleSystem.MinMaxGradient(new Color(1f, 1f, 1f, 0.35f));
+        }
+        else if (string.Equals(name, "thrusterMistR", StringComparison.Ordinal))
+        {
+            emission.rateOverTimeMultiplier = 1f;
+            main.startSizeMultiplier = 7f;
+            main.startSpeedMultiplier = 24f;
+            main.startLifetimeMultiplier = 1.2f;
+            main.maxParticles = 45;
+            main.startColor = new ParticleSystem.MinMaxGradient(new Color(1f, 1f, 1f, 0.28f));
+        }
     }
 
     private void ApplyEnvironmentRenderSettings()
@@ -1122,7 +1552,7 @@ public sealed class NativeMenuEnvironment : MonoBehaviour
 
     private static bool IsShipPreviewHiddenChild(Transform transform)
     {
-        return ContainsIgnoreCase(transform.name, "hangarDoor") ||
+        return HiddenShipPreviewChildNames.Contains(transform.name) ||
                ContainsIgnoreCase(transform.name, "lod");
     }
 
@@ -1139,6 +1569,12 @@ public sealed class NativeMenuEnvironment : MonoBehaviour
                string.Equals(transform.name, "contactSparks", StringComparison.OrdinalIgnoreCase) ||
                string.Equals(transform.name, "helmetCamPoint (1)", StringComparison.OrdinalIgnoreCase) ||
                ContainsIgnoreCase(transform.name, "lod") ||
+               string.Equals(transform.name, "navlight_L", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(transform.name, "navlight_R", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(transform.name, "navlight_effects_L", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(transform.name, "navlight_effects_R", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(transform.name, "spotlight_L", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(transform.name, "spotlight_R", StringComparison.OrdinalIgnoreCase) ||
                string.Equals(transform.name, "joystick", StringComparison.OrdinalIgnoreCase) ||
                string.Equals(transform.name, "collective", StringComparison.OrdinalIgnoreCase) ||
                string.Equals(transform.name, "ladder", StringComparison.OrdinalIgnoreCase);
@@ -1156,136 +1592,6 @@ public sealed class NativeMenuEnvironment : MonoBehaviour
                 child.gameObject.SetActive(active);
             }
         }
-    }
-
-    private static void RestorePreviewEffectObject(GameObject root, string objectName)
-    {
-        var target = FindChildByName(root.transform, objectName);
-        if (target == null)
-        {
-            Debug.LogWarning($"[NOVR] Native menu environment could not find preview effect object '{objectName}'.");
-            return;
-        }
-
-        var changed = false;
-        if (!target.gameObject.activeSelf)
-        {
-            target.gameObject.SetActive(true);
-            changed = true;
-        }
-
-        var lights = target.GetComponentsInChildren<Light>(true);
-        for (var index = 0; index < lights.Length; index++)
-        {
-            var light = lights[index];
-            if (light == null) continue;
-
-            if (!light.gameObject.activeSelf)
-            {
-                light.gameObject.SetActive(true);
-                changed = true;
-            }
-
-            if (!light.enabled)
-            {
-                light.enabled = true;
-                changed = true;
-            }
-
-            if (light.cullingMask != ~0)
-            {
-                light.cullingMask = ~0;
-                changed = true;
-            }
-        }
-
-        var renderers = target.GetComponentsInChildren<Renderer>(true);
-        for (var index = 0; index < renderers.Length; index++)
-        {
-            var renderer = renderers[index];
-            if (renderer == null) continue;
-            if (RendererUsesMainTexture(renderer, NavLightStarburstTextureName)) continue;
-
-            if (!renderer.gameObject.activeSelf)
-            {
-                renderer.gameObject.SetActive(true);
-                changed = true;
-            }
-
-            if (!renderer.enabled)
-            {
-                renderer.enabled = true;
-                changed = true;
-            }
-        }
-
-        var particleSystems = target.GetComponentsInChildren<ParticleSystem>(true);
-        for (var index = 0; index < particleSystems.Length; index++)
-        {
-            var particleSystem = particleSystems[index];
-            if (particleSystem == null) continue;
-
-            if (!particleSystem.gameObject.activeSelf)
-            {
-                particleSystem.gameObject.SetActive(true);
-                changed = true;
-            }
-
-            if (!particleSystem.isPlaying)
-            {
-                particleSystem.Play(true);
-                changed = true;
-            }
-        }
-
-        if (changed)
-        {
-            Debug.Log($"[NOVR] Native menu environment restored preview effect object '{objectName}'.");
-        }
-    }
-
-    private static void HideNavLightStarburstRenderers(GameObject root)
-    {
-        HideNavLightStarburstRenderers(root, "navlight_effects_L");
-        HideNavLightStarburstRenderers(root, "navlight_effects_R");
-    }
-
-    private static void HideNavLightStarburstRenderers(GameObject root, string effectRootName)
-    {
-        var effectRoot = FindChildByName(root.transform, effectRootName);
-        if (effectRoot == null) return;
-
-        var renderers = effectRoot.GetComponentsInChildren<Renderer>(true);
-        for (var index = 0; index < renderers.Length; index++)
-        {
-            var renderer = renderers[index];
-            if (renderer == null || !RendererUsesMainTexture(renderer, NavLightStarburstTextureName)) continue;
-
-            if (renderer.enabled)
-            {
-                renderer.enabled = false;
-                Debug.Log($"[NOVR] Native menu environment disabled navlight starburst renderer '{GetTransformPath(renderer.transform)}'.");
-            }
-        }
-    }
-
-    private static bool RendererUsesMainTexture(Renderer renderer, string textureName)
-    {
-        var materials = renderer.sharedMaterials;
-        if (materials == null) return false;
-
-        for (var index = 0; index < materials.Length; index++)
-        {
-            var material = materials[index];
-            if (material == null || material.mainTexture == null) continue;
-
-            if (string.Equals(material.mainTexture.name, textureName, StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     private static Transform? FindChildByName(Transform root, string objectName)

--- a/NOVR/VrUi/Native/NativeMenuEnvironment.cs
+++ b/NOVR/VrUi/Native/NativeMenuEnvironment.cs
@@ -12,34 +12,24 @@ namespace NOVR.VrUi.Native;
 
 public sealed class NativeMenuEnvironment : MonoBehaviour
 {
+    private const string EnvironmentSceneName = "NOVR Menu Environment Scene";
     private const string EnvironmentRootName = "NOVR Native Menu Environment";
     private const string VisualRootName = "Visuals";
     private const string PreviewUnitName = "AttackHelo1";
     private const string PreviewShipName = "Frigate1";
     private const string NavLightStarburstTextureName = "starburst";
-    private const string BackdropWaterName = "BackdropWater";
-    private const string WaterUnderLayerName = "waterUnderLayer";
-    private const string MenuBackdropWaterName = "Menu Environment BackdropWater";
-    private const string CloudPlaneName = "cloudPlane";
-    private const string MenuCloudPlaneName = "NOVR Menu Environment Cloud Plane";
+    private const string SimpleWaterPlaneName = "NOVR Menu Environment Water Plane";
     private const string MenuCameraName = "Menu Camera";
     private const string DefaultSkyboxMaterialName = "Default-Skybox";
     private const string EncyclopediaSceneName = "Encyclopedia";
-    private const string EncyclopediaScenePath = "Assets/Scenes/Encyclopedia/Encyclopedia.unity";
     private const float EnvironmentCameraFarClipPlane = 80000f;
     private const float MenuEnvironmentFogDensity = 0.00105f;
-    private const float MissingAssetRetryIntervalSeconds = 1f;
-    private const float AssetWarmupRetryIntervalSeconds = 3f;
-    private const float AssetWarmupStartupDelaySeconds = 2f;
-    private const float AssetWarmupReadyTimeoutSeconds = 12f;
     private static readonly Vector3 MenuEnvironmentWorldAnchor = new(-23.8808f, 2.774f, -821.3446f);
-    private static readonly Vector3 WaterLocalPosition = new(0f, -10f, -9.66f);
-    private static readonly Vector3 CloudPlaneLocalPosition = new(0f, 500f, 0f);
-    private static readonly Vector3 CloudPlaneLocalScale = new(1f, 10f, 1f);
+    private static readonly Vector3 SimpleWaterPlaneLocalPosition = new(0f, -10f, -9.66f);
+    private static readonly Vector3 SimpleWaterPlaneLocalScale = new(9000f, 1f, 9000f);
     private static readonly Color MenuEnvironmentFogColor = new(0.52f, 0.68f, 0.80f, 1f);
-    private static readonly Color CloudMaterialColor = new(3.75f, 3.78f, 1.72f, 0.98f);
-    private static readonly Color CloudLayerParticleColor = new(1f, 1f, 1f, 0.5f);
-    private static readonly Color DistantCloudParticleColor = Color.white;
+    private static readonly Color SimpleWaterBaseColor = new(0.12f, 0.32f, 0.42f, 1f);
+    private static readonly Color SimpleWaterHighlightColor = new(0.28f, 0.58f, 0.70f, 1f);
     private static readonly Vector3 ShipHangarSourceAnchor = new(0f, 3.8098f, -22.1115f);
     private static readonly Vector3 ShipHangarTargetAnchor = new(0f, 1.25f, 0.45f);
     private static readonly Vector3 PreviewLocalOffset = new(23.8808f, -2.774f, 821.3446f);
@@ -85,16 +75,9 @@ public sealed class NativeMenuEnvironment : MonoBehaviour
     private Transform? _visualRoot;
     private GameObject? _shipRoot;
     private GameObject? _previewUnit;
-    private GameObject? _waterBackdrop;
-    private GameObject? _waterUnderLayer;
-    private GameObject? _cloudPlane;
-    private Material? _originalSkybox;
-    private Color _originalAmbientLight;
-    private AmbientMode _originalAmbientMode;
-    private bool _originalFog;
-    private Color _originalFogColor;
-    private float _originalFogDensity;
-    private FogMode _originalFogMode;
+    private GameObject? _waterPlane;
+    private Material? _waterMaterial;
+    private Texture2D? _waterTexture;
     private Camera? _environmentCamera;
     private CameraClearFlags _originalEnvironmentCameraClearFlags;
     private Color _originalEnvironmentCameraBackgroundColor;
@@ -102,37 +85,50 @@ public sealed class NativeMenuEnvironment : MonoBehaviour
     private int _originalEnvironmentCameraCullingMask;
     private bool _originalEnvironmentCameraRenderPostProcessing;
     private Volume? _postProcessingVolume;
-    private bool _renderSettingsCaptured;
     private bool _environmentRenderSettingsApplied;
     private bool _environmentCameraSettingsCaptured;
+    private bool _gameStateListenerRegistered;
+    private bool _sceneUnloadedListenerRegistered;
+    private Scene _environmentScene;
+    private RenderSettingsSnapshot _originalRenderSettings;
+    private bool _renderSettingsCaptured;
     private bool _spawnAttempted;
-    private bool _assetWarmupStarted;
-    private bool _assetWarmupComplete;
-    private bool _assetWarmupFailed;
-    private Scene _warmupScene;
-    private bool _warmupSceneLoadedByEnvironment;
-    private float _nextAssetWarmupAttemptTime;
-    private float _nextMissingAssetRetryTime;
-    private static GameObject[]? _resourceGameObjectCache;
-    private static int _lastLoggedResourceGameObjectCount = -1;
+
+    private struct RenderSettingsSnapshot
+    {
+        public Material? Skybox;
+        public AmbientMode AmbientMode;
+        public Color AmbientLight;
+        public Color AmbientSkyColor;
+        public Color AmbientEquatorColor;
+        public Color AmbientGroundColor;
+        public float AmbientIntensity;
+        public bool Fog;
+        public FogMode FogMode;
+        public Color FogColor;
+        public float FogDensity;
+        public float FogStartDistance;
+        public float FogEndDistance;
+        public float ReflectionIntensity;
+    }
 
     public void UpdateEnvironment(Transform menuTransform, bool shouldShow)
     {
         var enabled = shouldShow && ModConfiguration.Instance.EnableNativeMenuEnvironment.Value;
         if (!enabled)
         {
-            SetVisible(false);
-            RestoreEnvironmentCameraSettings();
-            RestoreEnvironmentRenderSettings();
+            Hide();
+            return;
+        }
+
+        if (!EnsureEnvironmentScene())
+        {
             return;
         }
 
         EnsureRoot();
         PlaceRoot(menuTransform);
-        RefreshMissingAssetCachesIfNeeded();
-        EnsureEnvironmentAssetWarmup();
-        EnsureGameWaterObjects();
-        EnsureCloudPlane();
+        EnsureSimpleWaterPlane();
         ApplyEnvironmentRenderSettings();
         ApplyEnvironmentCameraSettings();
         EnsurePreviewScene();
@@ -140,6 +136,19 @@ public sealed class NativeMenuEnvironment : MonoBehaviour
         ApplyShipVisualOverrides();
         ApplyAircraftVisualOverrides();
         RestorePreviewEffectObjects();
+    }
+
+    private void OnEnable()
+    {
+        RegisterGameStateListener();
+        RegisterSceneUnloadedListener();
+    }
+
+    private void OnDisable()
+    {
+        UnregisterGameStateListener();
+        UnregisterSceneUnloadedListener();
+        Hide();
     }
 
     public void Hide()
@@ -151,126 +160,145 @@ public sealed class NativeMenuEnvironment : MonoBehaviour
 
     private void OnDestroy()
     {
+        UnregisterGameStateListener();
+        UnregisterSceneUnloadedListener();
+        DestroyEnvironmentScene();
+    }
+
+    private void RegisterGameStateListener()
+    {
+        if (_gameStateListenerRegistered) return;
+
+        GameManager.OnGameStateChanged.AddListener(OnGameStateChanged);
+        _gameStateListenerRegistered = true;
+    }
+
+    private void UnregisterGameStateListener()
+    {
+        if (!_gameStateListenerRegistered) return;
+
+        GameManager.OnGameStateChanged.RemoveListener(OnGameStateChanged);
+        _gameStateListenerRegistered = false;
+    }
+
+    private void OnGameStateChanged()
+    {
+        if (GameManager.gameState == GameState.Menu) return;
+
+        DestroyEnvironmentScene();
+    }
+
+    private void RegisterSceneUnloadedListener()
+    {
+        if (_sceneUnloadedListenerRegistered) return;
+
+        SceneManager.sceneUnloaded += OnSceneUnloaded;
+        _sceneUnloadedListenerRegistered = true;
+    }
+
+    private void UnregisterSceneUnloadedListener()
+    {
+        if (!_sceneUnloadedListenerRegistered) return;
+
+        SceneManager.sceneUnloaded -= OnSceneUnloaded;
+        _sceneUnloadedListenerRegistered = false;
+    }
+
+    private void OnSceneUnloaded(Scene scene)
+    {
+        if (!string.Equals(scene.name, EnvironmentSceneName, StringComparison.OrdinalIgnoreCase)) return;
+
+        ClearEnvironmentSceneObjectReferences();
+        ResetSceneScopedRenderingState();
+        _environmentScene = default;
+        Debug.Log($"[NOVR] Native menu environment cleared cached objects after scene '{EnvironmentSceneName}' unloaded.");
+    }
+
+    private bool EnsureEnvironmentScene()
+    {
+        if (_environmentScene.IsValid() && _environmentScene.isLoaded)
+        {
+            ResetSceneObjectReferencesIfDestroyed();
+            return true;
+        }
+
+        ClearEnvironmentSceneObjectReferences();
+
+        var existingScene = FindLoadedSceneByName(EnvironmentSceneName);
+        if (existingScene.IsValid() && existingScene.isLoaded)
+        {
+            _environmentScene = existingScene;
+            return true;
+        }
+
+        _environmentScene = SceneManager.CreateScene(EnvironmentSceneName);
+        if (!_environmentScene.IsValid() || !_environmentScene.isLoaded)
+        {
+            Debug.LogWarning("[NOVR] Native menu environment could not create its scene.");
+            _environmentScene = default;
+            return false;
+        }
+
+        Debug.Log($"[NOVR] Native menu environment created scene '{_environmentScene.name}'.");
+        return true;
+    }
+
+    private void DestroyEnvironmentScene()
+    {
+        SetVisible(false);
+        StopAllCoroutines();
         RestoreEnvironmentCameraSettings();
         RestoreEnvironmentRenderSettings();
-        UnloadWarmupScene();
+        ClearEnvironmentSceneObjectReferences(destroyRoot: true);
+
+        if (_environmentScene.IsValid() && _environmentScene.isLoaded)
+        {
+            SceneManager.UnloadSceneAsync(_environmentScene);
+            Debug.Log($"[NOVR] Native menu environment unloaded scene '{EnvironmentSceneName}'.");
+        }
+
+        _environmentScene = default;
     }
 
-    private void EnsureEnvironmentAssetWarmup()
+    private void ResetSceneObjectReferencesIfDestroyed()
     {
-        if (_assetWarmupStarted ||
-            _assetWarmupComplete ||
-            (HasGameWaterObjects() && _cloudPlane != null))
-        {
-            return;
-        }
+        if (_environmentRoot != null) return;
 
-        if (_assetWarmupFailed && Time.unscaledTime < _nextAssetWarmupAttemptTime)
-        {
-            return;
-        }
-
-        _assetWarmupFailed = false;
-        _assetWarmupStarted = true;
-        StartCoroutine(WarmEncyclopediaSceneAssets());
+        ClearEnvironmentSceneObjectReferences();
     }
 
-    private IEnumerator WarmEncyclopediaSceneAssets()
+    private void ClearEnvironmentSceneObjectReferences(bool destroyRoot = false)
     {
-        var startTime = Time.unscaledTime;
-        while (Time.unscaledTime - startTime < AssetWarmupStartupDelaySeconds)
+        if (destroyRoot && _environmentRoot != null)
         {
-            yield return null;
+            Object.Destroy(_environmentRoot);
         }
 
-        startTime = Time.unscaledTime;
-        while (Encyclopedia.i == null && Time.unscaledTime - startTime < AssetWarmupReadyTimeoutSeconds)
-        {
-            yield return null;
-        }
+        DestroySimpleWaterResources();
 
-        var scene = FindLoadedScene(EncyclopediaScenePath, EncyclopediaSceneName);
-        if (!scene.IsValid())
-        {
-            Debug.Log($"[NOVR] Native menu environment loading '{EncyclopediaScenePath}' additively to warm environment assets.");
-
-            AsyncOperation? loadOperation;
-            try
-            {
-                loadOperation = SceneManager.LoadSceneAsync(EncyclopediaScenePath, LoadSceneMode.Additive);
-            }
-            catch (Exception exception)
-            {
-                MarkAssetWarmupFailed($"could not start Encyclopedia scene warmup: {exception}");
-                yield break;
-            }
-
-            if (loadOperation == null)
-            {
-                MarkAssetWarmupFailed($"SceneManager could not start loading '{EncyclopediaScenePath}'.");
-                yield break;
-            }
-
-            yield return loadOperation;
-
-            scene = FindLoadedScene(EncyclopediaScenePath, EncyclopediaSceneName);
-            if (!scene.IsValid() || !scene.isLoaded)
-            {
-                MarkAssetWarmupFailed($"SceneManager finished loading '{EncyclopediaScenePath}', but the scene was not available.");
-                yield break;
-            }
-
-            _warmupScene = scene;
-            _warmupSceneLoadedByEnvironment = true;
-            Debug.Log($"[NOVR] Native menu environment loaded warmup scene '{scene.name}' with {scene.rootCount} root objects.");
-        }
-        else
-        {
-            Debug.Log($"[NOVR] Native menu environment using already-loaded warmup scene '{scene.name}'.");
-        }
-
-        DisableWarmupSceneRoots(scene, _warmupSceneLoadedByEnvironment);
-        yield return null;
-        yield return new WaitForEndOfFrame();
-        _resourceGameObjectCache = null;
-        EnsureGameWaterObjects();
-        EnsureCloudPlane();
-
-        _assetWarmupComplete = HasGameWaterObjects() && _cloudPlane != null;
-        _assetWarmupFailed = !_assetWarmupComplete;
-        _assetWarmupStarted = false;
-        var loadedWarmupScene = _warmupSceneLoadedByEnvironment;
-
-        if (_assetWarmupComplete && _warmupSceneLoadedByEnvironment)
-        {
-            UnloadWarmupScene();
-        }
-
-        if (_assetWarmupFailed)
-        {
-            _nextAssetWarmupAttemptTime = Time.unscaledTime + AssetWarmupRetryIntervalSeconds;
-        }
-
-        Debug.Log(
-            "[NOVR] Native menu environment Encyclopedia scene warmup finished: " +
-            $"water={HasGameWaterObjects()}, cloudPlane={_cloudPlane != null}, sceneLoadedByEnvironment={loadedWarmupScene}.");
+        _environmentRoot = null;
+        _visualRoot = null;
+        _shipRoot = null;
+        _previewUnit = null;
+        _waterPlane = null;
+        _spawnAttempted = false;
     }
 
-    private void MarkAssetWarmupFailed(string message)
+    private void ResetSceneScopedRenderingState()
     {
-        _assetWarmupStarted = false;
-        _assetWarmupFailed = true;
-        _nextAssetWarmupAttemptTime = Time.unscaledTime + AssetWarmupRetryIntervalSeconds;
-        Debug.LogWarning($"[NOVR] Native menu environment {message} Retrying.");
+        _postProcessingVolume = null;
+        _environmentCamera = null;
+        _environmentCameraSettingsCaptured = false;
+        _environmentRenderSettingsApplied = false;
+        _renderSettingsCaptured = false;
     }
 
-    private static Scene FindLoadedScene(string scenePath, string sceneName)
+    private static Scene FindLoadedSceneByName(string sceneName)
     {
         for (var index = 0; index < SceneManager.sceneCount; index++)
         {
             var scene = SceneManager.GetSceneAt(index);
-            if (string.Equals(scene.path, scenePath, StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(scene.name, sceneName, StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(scene.name, sceneName, StringComparison.OrdinalIgnoreCase))
             {
                 return scene;
             }
@@ -279,41 +307,15 @@ public sealed class NativeMenuEnvironment : MonoBehaviour
         return default;
     }
 
-    private void UnloadWarmupScene()
-    {
-        if (!_warmupSceneLoadedByEnvironment || !_warmupScene.IsValid() || !_warmupScene.isLoaded) return;
-
-        SceneManager.UnloadSceneAsync(_warmupScene);
-        _warmupScene = default;
-        _warmupSceneLoadedByEnvironment = false;
-    }
-
-    private static void DisableWarmupSceneRoots(Scene scene, bool stripWeatherBehaviours)
-    {
-        if (!scene.IsValid() || !scene.isLoaded) return;
-
-        var roots = scene.GetRootGameObjects();
-        for (var index = 0; index < roots.Length; index++)
-        {
-            var root = roots[index];
-            if (root != null)
-            {
-                if (stripWeatherBehaviours)
-                {
-                    StripCloudPlaneGameplayComponents(root);
-                }
-
-                root.SetActive(false);
-            }
-        }
-    }
-
     private void EnsureRoot()
     {
         if (_environmentRoot != null) return;
 
         _environmentRoot = new GameObject(EnvironmentRootName);
-        DontDestroyOnLoad(_environmentRoot);
+        if (_environmentScene.IsValid() && _environmentScene.isLoaded)
+        {
+            SceneManager.MoveGameObjectToScene(_environmentRoot, _environmentScene);
+        }
 
         var visualRoot = new GameObject(VisualRootName);
         visualRoot.transform.SetParent(_environmentRoot.transform, false);
@@ -322,473 +324,163 @@ public sealed class NativeMenuEnvironment : MonoBehaviour
         Debug.Log("[NOVR] Native menu environment root created.");
     }
 
-    private void EnsureGameWaterObjects()
+    private void EnsureSimpleWaterPlane()
     {
-        if (_visualRoot == null || HasGameWaterObjects()) return;
+        if (_visualRoot == null || _waterPlane != null) return;
 
-        var backdropSource = FindWaterObjectSource(BackdropWaterName);
-        if (backdropSource == null) return;
+        _waterPlane = GameObject.CreatePrimitive(PrimitiveType.Plane);
+        _waterPlane.name = SimpleWaterPlaneName;
+        _waterPlane.transform.SetParent(_visualRoot, false);
+        _waterPlane.transform.localPosition = SimpleWaterPlaneLocalPosition;
+        _waterPlane.transform.localRotation = Quaternion.identity;
+        _waterPlane.transform.localScale = SimpleWaterPlaneLocalScale;
+        LayerHelper.SetLayerRecursive(_waterPlane.transform, LayerHelper.GetVrUiLayer());
 
-        _waterBackdrop = CloneGameWaterObject(backdropSource, MenuBackdropWaterName, WaterLocalPosition);
-        _waterUnderLayer = FindChildByName(_waterBackdrop.transform, WaterUnderLayerName)?.gameObject;
-
-        Debug.Log(
-            "[NOVR] Native menu environment cloned game water from " +
-            $"'{GetTransformPath(backdropSource.transform)}' underLayer={_waterUnderLayer != null}.");
-    }
-
-    private static GameObject? FindWaterObjectSource(string objectName)
-    {
-        var objects = Resources.FindObjectsOfTypeAll<GameObject>();
-
-        for (var index = 0; index < objects.Length; index++)
+        var collider = _waterPlane.GetComponent<Collider>();
+        if (collider != null)
         {
-            var gameObject = objects[index];
-            if (gameObject == null ||
-                IsUnderNativeMenuEnvironment(gameObject.transform) ||
-                !string.Equals(gameObject.name, objectName, StringComparison.OrdinalIgnoreCase))
+            collider.enabled = false;
+            Object.Destroy(collider);
+        }
+
+        var renderer = _waterPlane.GetComponent<MeshRenderer>();
+        if (renderer != null)
+        {
+            var waterMaterial = CreateSimpleWaterMaterial();
+            if (waterMaterial != null)
             {
-                continue;
+                renderer.sharedMaterial = waterMaterial;
+            }
+            else
+            {
+                renderer.enabled = false;
             }
 
-            if (string.Equals(gameObject.scene.name, EncyclopediaSceneName, StringComparison.OrdinalIgnoreCase))
+            renderer.shadowCastingMode = ShadowCastingMode.Off;
+            renderer.receiveShadows = false;
+        }
+
+        Debug.Log("[NOVR] Native menu environment created simple water plane.");
+    }
+
+    private Material? CreateSimpleWaterMaterial()
+    {
+        if (_waterMaterial != null) return _waterMaterial;
+
+        var shader = Shader.Find("Universal Render Pipeline/Lit") ??
+                     Shader.Find("Universal Render Pipeline/Unlit") ??
+                     Shader.Find("Standard") ??
+                     Shader.Find("Sprites/Default");
+        if (shader == null)
+        {
+            Debug.LogWarning("[NOVR] Native menu environment could not find a shader for the simple water plane.");
+            return null;
+        }
+
+        var material = new Material(shader)
+        {
+            name = "NOVR Menu Environment Water"
+        };
+
+        var texture = CreateSimpleWaterTexture();
+        SetMaterialTexture(material, texture);
+        SetMaterialColor(material, SimpleWaterBaseColor);
+        SetMaterialFloat(material, "_Smoothness", 0.72f);
+        SetMaterialFloat(material, "_Metallic", 0f);
+        SetMaterialTextureScale(material, new Vector2(280f, 280f));
+
+        _waterMaterial = material;
+        _waterTexture = texture;
+        return material;
+    }
+
+    private static Texture2D CreateSimpleWaterTexture()
+    {
+        const int size = 128;
+        var texture = new Texture2D(size, size, TextureFormat.RGBA32, true)
+        {
+            name = "NOVR Menu Environment Water Texture",
+            wrapMode = TextureWrapMode.Repeat,
+            filterMode = FilterMode.Trilinear,
+            anisoLevel = 4
+        };
+
+        for (var y = 0; y < size; y++)
+        {
+            for (var x = 0; x < size; x++)
             {
-                return gameObject;
+                var waveA = Mathf.Sin((x + y * 0.55f) * 0.22f);
+                var waveB = Mathf.Sin((x * -0.35f + y) * 0.15f);
+                var ripple = Mathf.PerlinNoise(x * 0.075f, y * 0.075f);
+                var t = Mathf.Clamp01(0.48f + waveA * 0.10f + waveB * 0.06f + (ripple - 0.5f) * 0.16f);
+                texture.SetPixel(x, y, Color.Lerp(SimpleWaterBaseColor, SimpleWaterHighlightColor, t));
             }
         }
 
-        return null;
+        texture.Apply(true, true);
+        return texture;
     }
 
-    private GameObject CloneGameWaterObject(GameObject source, string name, Vector3 localPosition)
+    private static void SetMaterialTexture(Material material, Texture texture)
     {
-        var clone = Object.Instantiate(source);
-        clone.name = name;
-        clone.SetActive(false);
-        clone.transform.SetParent(_visualRoot, false);
-        clone.transform.localPosition = localPosition;
-        clone.transform.localRotation = source.transform.localRotation;
-        clone.transform.localScale = source.transform.localScale;
-
-        PrepareGameWaterObject(clone);
-        clone.SetActive(true);
-        PrepareGameWaterObject(clone);
-        LogWaterObjectState(clone);
-
-        return clone;
-    }
-
-    private static void PrepareGameWaterObject(GameObject root)
-    {
-        var colliders = root.GetComponentsInChildren<Collider>(true);
-        for (var index = 0; index < colliders.Length; index++)
+        if (material.HasProperty("_BaseMap"))
         {
-            var collider = colliders[index];
-            if (collider != null)
-            {
-                collider.enabled = false;
-            }
+            material.SetTexture("_BaseMap", texture);
         }
 
-        var cameras = root.GetComponentsInChildren<Camera>(true);
-        for (var index = 0; index < cameras.Length; index++)
+        if (material.HasProperty("_MainTex"))
         {
-            var camera = cameras[index];
-            if (camera != null)
-            {
-                camera.enabled = false;
-            }
-        }
-
-        var renderers = root.GetComponentsInChildren<Renderer>(true);
-        for (var index = 0; index < renderers.Length; index++)
-        {
-            var renderer = renderers[index];
-            if (renderer == null) continue;
-
-            EnsureUniqueWaterMaterials(renderer);
-            renderer.enabled = !IsWaterUnderLayer(renderer.transform);
-            renderer.forceRenderingOff = false;
-        }
-
-        SyncWaterMaterialOriginOffset(root);
-    }
-
-    private static bool IsWaterUnderLayer(Transform transform)
-    {
-        while (transform != null)
-        {
-            if (string.Equals(transform.name, WaterUnderLayerName, StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-
-            transform = transform.parent;
-        }
-
-        return false;
-    }
-
-    private static void EnsureUniqueWaterMaterials(Renderer renderer)
-    {
-        var materials = renderer.sharedMaterials;
-        var changed = false;
-
-        for (var index = 0; index < materials.Length; index++)
-        {
-            var material = materials[index];
-            if (material == null || material.name.EndsWith(" NOVR", StringComparison.Ordinal)) continue;
-
-            materials[index] = new Material(material)
-            {
-                name = $"{material.name} NOVR"
-            };
-            changed = true;
-        }
-
-        if (changed)
-        {
-            renderer.sharedMaterials = materials;
+            material.SetTexture("_MainTex", texture);
         }
     }
 
-    private static void SyncWaterMaterialOriginOffset(GameObject root)
+    private static void SetMaterialTextureScale(Material material, Vector2 scale)
     {
-        var localPosition = root.transform.localPosition;
-        var originOffset = new Vector4(-localPosition.x, -localPosition.z, 0f, 0f);
-
-        var renderers = root.GetComponentsInChildren<Renderer>(true);
-        for (var rendererIndex = 0; rendererIndex < renderers.Length; rendererIndex++)
+        if (material.HasProperty("_BaseMap"))
         {
-            var renderer = renderers[rendererIndex];
-            if (renderer == null) continue;
+            material.SetTextureScale("_BaseMap", scale);
+        }
 
-            var materials = renderer.sharedMaterials;
-            for (var materialIndex = 0; materialIndex < materials.Length; materialIndex++)
-            {
-                var material = materials[materialIndex];
-                if (material == null || !material.HasProperty("_OriginOffset")) continue;
-
-                material.SetVector("_OriginOffset", originOffset);
-            }
+        if (material.HasProperty("_MainTex"))
+        {
+            material.SetTextureScale("_MainTex", scale);
         }
     }
 
-    private static void LogWaterObjectState(GameObject root)
+    private static void SetMaterialColor(Material material, Color color)
     {
-        var builder = new System.Text.StringBuilder();
-        builder.Append("[NOVR] Native menu environment water clone state:");
-
-        var renderers = root.GetComponentsInChildren<Renderer>(true);
-        for (var rendererIndex = 0; rendererIndex < renderers.Length; rendererIndex++)
-        {
-            var renderer = renderers[rendererIndex];
-            if (renderer == null) continue;
-
-            builder
-                .AppendLine()
-                .Append("  renderer=")
-                .Append(GetTransformPath(renderer.transform))
-                .Append(" layer=")
-                .Append(renderer.gameObject.layer)
-                .Append(" enabled=")
-                .Append(renderer.enabled);
-
-            var materials = renderer.sharedMaterials;
-            for (var materialIndex = 0; materialIndex < materials.Length; materialIndex++)
-            {
-                var material = materials[materialIndex];
-                if (material == null) continue;
-
-                builder
-                    .AppendLine()
-                    .Append("    material=")
-                    .Append(material.name)
-                    .Append(" shader=")
-                    .Append(material.shader != null ? material.shader.name : "null")
-                    .Append(" queue=")
-                    .Append(material.renderQueue);
-            }
-        }
-
-        Debug.Log(builder.ToString());
-    }
-
-    private bool HasGameWaterObjects()
-    {
-        return _waterBackdrop != null;
-    }
-
-    private void EnsureCloudPlane()
-    {
-        if (_visualRoot == null || _cloudPlane != null) return;
-
-        var cloudSource = FindCloudPlaneSource();
-        if (cloudSource == null) return;
-
-        _cloudPlane = Object.Instantiate(cloudSource);
-        _cloudPlane.name = MenuCloudPlaneName;
-        _cloudPlane.SetActive(false);
-        _cloudPlane.transform.SetParent(_visualRoot, false);
-        _cloudPlane.transform.localPosition = CloudPlaneLocalPosition;
-        _cloudPlane.transform.localRotation = Quaternion.identity;
-        _cloudPlane.transform.localScale = CloudPlaneLocalScale;
-
-        PrepareCloudPlane(_cloudPlane);
-        _cloudPlane.AddComponent<MenuEnvironmentCloudWind>();
-        _cloudPlane.SetActive(true);
-        PrepareCloudPlane(_cloudPlane);
-
-        Debug.Log($"[NOVR] Native menu environment cloned cloud plane from '{GetTransformPath(cloudSource.transform)}'.");
-    }
-
-    private static GameObject? FindCloudPlaneSource()
-    {
-        var objects = Resources.FindObjectsOfTypeAll<GameObject>();
-        GameObject? fallback = null;
-
-        for (var index = 0; index < objects.Length; index++)
-        {
-            var gameObject = objects[index];
-            if (gameObject == null ||
-                !string.Equals(gameObject.name, CloudPlaneName, StringComparison.OrdinalIgnoreCase) ||
-                IsUnderNativeMenuEnvironment(gameObject.transform))
-            {
-                continue;
-            }
-
-            if (string.Equals(gameObject.scene.name, "Encyclopedia", StringComparison.OrdinalIgnoreCase))
-            {
-                return gameObject;
-            }
-
-            fallback ??= gameObject;
-        }
-
-        return fallback ?? FindResourceGameObjectByName(CloudPlaneName);
-    }
-
-    private static void PrepareCloudPlane(GameObject root)
-    {
-        StripCloudPlaneGameplayComponents(root);
-        LayerHelper.SetLayerRecursive(root.transform, LayerHelper.GetVrUiLayer());
-        SetMatchingChildrenActive(root.transform, static transform => string.Equals(transform.name, "lightning", StringComparison.OrdinalIgnoreCase), false);
-        ApplyCloudMaterialOverrides(root);
-        ApplyCloudParticleOverrides(root);
-
-        var renderers = root.GetComponentsInChildren<Renderer>(true);
-        for (var index = 0; index < renderers.Length; index++)
-        {
-            var renderer = renderers[index];
-            if (renderer != null)
-            {
-                renderer.enabled = true;
-            }
-        }
-
-        var particleSystems = root.GetComponentsInChildren<ParticleSystem>(true);
-        for (var index = 0; index < particleSystems.Length; index++)
-        {
-            var particleSystem = particleSystems[index];
-            if (particleSystem == null ||
-                !particleSystem.gameObject.activeInHierarchy ||
-                ShouldKeepCloudParticleSystemStopped(particleSystem))
-            {
-                continue;
-            }
-
-            particleSystem.Play(true);
-        }
-    }
-
-    private static void ApplyCloudParticleOverrides(GameObject root)
-    {
-        var particleSystems = root.GetComponentsInChildren<ParticleSystem>(true);
-        for (var index = 0; index < particleSystems.Length; index++)
-        {
-            var particleSystem = particleSystems[index];
-            if (particleSystem == null) continue;
-
-            if (IsCloudPlaneParticleSystem(root, particleSystem))
-            {
-                ConfigureCloudLayerParticles(particleSystem);
-                continue;
-            }
-
-            if (string.Equals(particleSystem.gameObject.name, "distantClouds", StringComparison.OrdinalIgnoreCase))
-            {
-                ConfigureDistantCloudParticles(particleSystem);
-                continue;
-            }
-
-            if (ShouldKeepCloudParticleSystemStopped(particleSystem))
-            {
-                particleSystem.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
-                particleSystem.gameObject.SetActive(false);
-            }
-        }
-    }
-
-    private static bool IsCloudPlaneParticleSystem(GameObject root, ParticleSystem particleSystem)
-    {
-        return particleSystem.gameObject == root ||
-               string.Equals(particleSystem.gameObject.name, CloudPlaneName, StringComparison.OrdinalIgnoreCase) ||
-               string.Equals(particleSystem.gameObject.name, MenuCloudPlaneName, StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static bool ShouldKeepCloudParticleSystemStopped(ParticleSystem particleSystem)
-    {
-        var name = particleSystem.gameObject.name;
-        return name.IndexOf("flyThrough", StringComparison.OrdinalIgnoreCase) >= 0 ||
-               string.Equals(name, "lightning", StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static void ConfigureCloudLayerParticles(ParticleSystem particleSystem)
-    {
-        var main = particleSystem.main;
-        main.duration = 1f;
-        main.loop = false;
-        main.prewarm = false;
-        main.startDelay = new ParticleSystem.MinMaxCurve(0f);
-        main.startLifetime = new ParticleSystem.MinMaxCurve(15.00058f);
-        main.startSpeed = new ParticleSystem.MinMaxCurve(0f);
-        main.startSize = new ParticleSystem.MinMaxCurve(479.8216f);
-        main.startRotation = new ParticleSystem.MinMaxCurve(0f);
-        main.startColor = new ParticleSystem.MinMaxGradient(CloudLayerParticleColor);
-        main.maxParticles = 3000;
-
-        var emission = particleSystem.emission;
-        emission.enabled = false;
-        emission.rateOverTime = new ParticleSystem.MinMaxCurve(1f);
-
-        var shape = particleSystem.shape;
-        shape.enabled = false;
-        shape.shapeType = ParticleSystemShapeType.Cone;
-        shape.radius = 1f;
-        shape.angle = 25f;
-        shape.arc = 360f;
-        shape.scale = Vector3.one;
-        shape.position = Vector3.zero;
-        shape.rotation = Vector3.zero;
-    }
-
-    private static void ConfigureDistantCloudParticles(ParticleSystem particleSystem)
-    {
-        var main = particleSystem.main;
-        main.duration = 20f;
-        main.loop = true;
-        main.prewarm = false;
-        main.startDelay = new ParticleSystem.MinMaxCurve(0f);
-        main.startLifetime = new ParticleSystem.MinMaxCurve(20f);
-        main.startSpeed = new ParticleSystem.MinMaxCurve(5f);
-        main.startSize = new ParticleSystem.MinMaxCurve(540f, 810f);
-        main.startRotation = new ParticleSystem.MinMaxCurve(0f);
-        main.startColor = new ParticleSystem.MinMaxGradient(DistantCloudParticleColor);
-        main.maxParticles = 300;
-
-        var emission = particleSystem.emission;
-        emission.enabled = true;
-        emission.rateOverTime = new ParticleSystem.MinMaxCurve(25f);
-
-        var shape = particleSystem.shape;
-        shape.enabled = true;
-        shape.shapeType = ParticleSystemShapeType.Circle;
-        shape.radius = 40000f;
-        shape.angle = 25f;
-        shape.arc = 360f;
-        shape.scale = Vector3.one;
-        shape.position = Vector3.zero;
-        shape.rotation = new Vector3(90f, 0f, 0f);
-    }
-
-    private static void ApplyCloudMaterialOverrides(GameObject root)
-    {
-        var renderers = root.GetComponentsInChildren<Renderer>(true);
-        for (var rendererIndex = 0; rendererIndex < renderers.Length; rendererIndex++)
-        {
-            var renderer = renderers[rendererIndex];
-            if (renderer == null) continue;
-
-            var materials = renderer.sharedMaterials;
-            var changed = false;
-
-            for (var materialIndex = 0; materialIndex < materials.Length; materialIndex++)
-            {
-                var material = materials[materialIndex];
-                if (material == null || !IsCloudMaterial(renderer, material)) continue;
-
-                if (!material.name.EndsWith(" NOVR", StringComparison.Ordinal))
-                {
-                    material = new Material(material)
-                    {
-                        name = $"{material.name} NOVR"
-                    };
-                    materials[materialIndex] = material;
-                    changed = true;
-                }
-
-                SetCloudMaterialColor(material);
-            }
-
-            if (changed)
-            {
-                renderer.sharedMaterials = materials;
-            }
-        }
-    }
-
-    private static bool IsCloudMaterial(Renderer renderer, Material material)
-    {
-        return ContainsCloudToken(renderer.gameObject.name) ||
-               ContainsCloudToken(material.name) ||
-               ContainsCloudToken(material.shader.name);
-    }
-
-    private static bool ContainsCloudToken(string value)
-    {
-        return value.IndexOf("cloud", StringComparison.OrdinalIgnoreCase) >= 0;
-    }
-
-    private static void SetCloudMaterialColor(Material material)
-    {
-        if (material.HasProperty("_CloudColor"))
-        {
-            material.SetColor("_CloudColor", CloudMaterialColor);
-        }
-
         if (material.HasProperty("_BaseColor"))
         {
-            material.SetColor("_BaseColor", CloudMaterialColor);
+            material.SetColor("_BaseColor", color);
         }
 
         if (material.HasProperty("_Color"))
         {
-            material.SetColor("_Color", CloudMaterialColor);
+            material.SetColor("_Color", color);
         }
     }
 
-    private static int StripCloudPlaneGameplayComponents(GameObject root)
+    private static void SetMaterialFloat(Material material, string propertyName, float value)
     {
-        var stripped = 0;
-        var components = root.GetComponentsInChildren<MonoBehaviour>(true);
-
-        for (var index = 0; index < components.Length; index++)
+        if (material.HasProperty(propertyName))
         {
-            var component = components[index];
-            if (component == null) continue;
+            material.SetFloat(propertyName, value);
+        }
+    }
 
-            if (!string.Equals(component.GetType().Name, "CloudLayer", StringComparison.Ordinal)) continue;
-
-            Object.DestroyImmediate(component);
-            stripped++;
+    private void DestroySimpleWaterResources()
+    {
+        if (_waterMaterial != null)
+        {
+            Object.Destroy(_waterMaterial);
+            _waterMaterial = null;
         }
 
-        if (stripped > 0)
+        if (_waterTexture != null)
         {
-            Debug.Log($"[NOVR] Native menu environment stripped {stripped} cloud gameplay component(s) from '{GetTransformPath(root.transform)}'.");
+            Object.Destroy(_waterTexture);
+            _waterTexture = null;
         }
-
-        return stripped;
     }
 
     private void PlaceRoot(Transform menuTransform)
@@ -1145,18 +837,62 @@ public sealed class NativeMenuEnvironment : MonoBehaviour
 
     private void RestoreEnvironmentRenderSettings()
     {
-        if (!_environmentRenderSettingsApplied || !_renderSettingsCaptured) return;
+        if (!_environmentRenderSettingsApplied && _postProcessingVolume == null && !_renderSettingsCaptured)
+        {
+            return;
+        }
 
-        RenderSettings.skybox = _originalSkybox;
-        RenderSettings.ambientMode = _originalAmbientMode;
-        RenderSettings.ambientLight = _originalAmbientLight;
-        RenderSettings.fog = _originalFog;
-        RenderSettings.fogColor = _originalFogColor;
-        RenderSettings.fogDensity = _originalFogDensity;
-        RenderSettings.fogMode = _originalFogMode;
-        _environmentRenderSettingsApplied = false;
         RemoveEnvironmentPostProcessing();
-        Debug.Log("[NOVR] Native menu environment restored skybox render settings.");
+        if (_renderSettingsCaptured)
+        {
+            RestoreRenderSettings(_originalRenderSettings);
+            _renderSettingsCaptured = false;
+        }
+
+        _environmentRenderSettingsApplied = false;
+        Debug.Log("[NOVR] Native menu environment restored scene render settings.");
+    }
+
+    private void CaptureRenderSettings()
+    {
+        if (_renderSettingsCaptured) return;
+
+        _originalRenderSettings = new RenderSettingsSnapshot
+        {
+            Skybox = RenderSettings.skybox,
+            AmbientMode = RenderSettings.ambientMode,
+            AmbientLight = RenderSettings.ambientLight,
+            AmbientSkyColor = RenderSettings.ambientSkyColor,
+            AmbientEquatorColor = RenderSettings.ambientEquatorColor,
+            AmbientGroundColor = RenderSettings.ambientGroundColor,
+            AmbientIntensity = RenderSettings.ambientIntensity,
+            Fog = RenderSettings.fog,
+            FogMode = RenderSettings.fogMode,
+            FogColor = RenderSettings.fogColor,
+            FogDensity = RenderSettings.fogDensity,
+            FogStartDistance = RenderSettings.fogStartDistance,
+            FogEndDistance = RenderSettings.fogEndDistance,
+            ReflectionIntensity = RenderSettings.reflectionIntensity,
+        };
+        _renderSettingsCaptured = true;
+    }
+
+    private static void RestoreRenderSettings(RenderSettingsSnapshot snapshot)
+    {
+        RenderSettings.skybox = snapshot.Skybox;
+        RenderSettings.ambientMode = snapshot.AmbientMode;
+        RenderSettings.ambientLight = snapshot.AmbientLight;
+        RenderSettings.ambientSkyColor = snapshot.AmbientSkyColor;
+        RenderSettings.ambientEquatorColor = snapshot.AmbientEquatorColor;
+        RenderSettings.ambientGroundColor = snapshot.AmbientGroundColor;
+        RenderSettings.ambientIntensity = snapshot.AmbientIntensity;
+        RenderSettings.fog = snapshot.Fog;
+        RenderSettings.fogMode = snapshot.FogMode;
+        RenderSettings.fogColor = snapshot.FogColor;
+        RenderSettings.fogDensity = snapshot.FogDensity;
+        RenderSettings.fogStartDistance = snapshot.FogStartDistance;
+        RenderSettings.fogEndDistance = snapshot.FogEndDistance;
+        RenderSettings.reflectionIntensity = snapshot.ReflectionIntensity;
     }
 
     private void ApplyEnvironmentPostProcessing()
@@ -1164,7 +900,15 @@ public sealed class NativeMenuEnvironment : MonoBehaviour
         if (_postProcessingVolume != null) return;
 
         var go = new GameObject("NOVR Menu Post Processing");
-        DontDestroyOnLoad(go);
+        if (_environmentScene.IsValid() && _environmentScene.isLoaded)
+        {
+            SceneManager.MoveGameObjectToScene(go, _environmentScene);
+        }
+
+        if (_environmentRoot != null)
+        {
+            go.transform.SetParent(_environmentRoot.transform, false);
+        }
 
         _postProcessingVolume = go.AddComponent<Volume>();
         _postProcessingVolume.isGlobal      = true;
@@ -1206,20 +950,6 @@ public sealed class NativeMenuEnvironment : MonoBehaviour
         Object.Destroy(_postProcessingVolume.gameObject);
         _postProcessingVolume = null;
         Debug.Log("[NOVR] Native menu environment removed post-processing volume.");
-    }
-
-    private void CaptureRenderSettings()
-    {
-        if (_renderSettingsCaptured) return;
-
-        _originalSkybox = RenderSettings.skybox;
-        _originalAmbientMode = RenderSettings.ambientMode;
-        _originalAmbientLight = RenderSettings.ambientLight;
-        _originalFog = RenderSettings.fog;
-        _originalFogColor = RenderSettings.fogColor;
-        _originalFogDensity = RenderSettings.fogDensity;
-        _originalFogMode = RenderSettings.fogMode;
-        _renderSettingsCaptured = true;
     }
 
     private void ApplyEnvironmentCameraSettings()
@@ -1323,15 +1053,6 @@ public sealed class NativeMenuEnvironment : MonoBehaviour
         return inactiveMatch;
     }
 
-    private void RefreshMissingAssetCachesIfNeeded()
-    {
-        if (HasGameWaterObjects() && _cloudPlane != null) return;
-        if (Time.unscaledTime < _nextMissingAssetRetryTime) return;
-
-        _nextMissingAssetRetryTime = Time.unscaledTime + MissingAssetRetryIntervalSeconds;
-        _resourceGameObjectCache = null;
-    }
-
     private static Material? FindSkyboxMaterial()
     {
         var defaultSkybox = FindMaterialByNormalizedName(DefaultSkyboxMaterialName);
@@ -1383,37 +1104,6 @@ public sealed class NativeMenuEnvironment : MonoBehaviour
         }
 
         return null;
-    }
-
-    private static GameObject? FindResourceGameObjectByName(string gameObjectName)
-    {
-        var resourceGameObjects = GetResourceGameObjectCache();
-        for (var index = 0; index < resourceGameObjects.Length; index++)
-        {
-            var gameObject = resourceGameObjects[index];
-            if (gameObject == null) continue;
-
-            if (string.Equals(gameObject.name, gameObjectName, StringComparison.OrdinalIgnoreCase))
-            {
-                return gameObject;
-            }
-        }
-
-        return null;
-    }
-
-    private static GameObject[] GetResourceGameObjectCache()
-    {
-        if (_resourceGameObjectCache != null) return _resourceGameObjectCache;
-
-        _resourceGameObjectCache = Resources.LoadAll<GameObject>(string.Empty);
-        if (_resourceGameObjectCache.Length != _lastLoggedResourceGameObjectCount)
-        {
-            _lastLoggedResourceGameObjectCount = _resourceGameObjectCache.Length;
-            Debug.Log($"[NOVR] Native menu environment scanned {_resourceGameObjectCache.Length} resource game objects.");
-        }
-
-        return _resourceGameObjectCache;
     }
 
     private static string NormalizeUnityObjectName(string name)
@@ -1630,22 +1320,6 @@ public sealed class NativeMenuEnvironment : MonoBehaviour
     private static bool ContainsIgnoreCase(string text, string value)
     {
         return text.IndexOf(value, StringComparison.OrdinalIgnoreCase) >= 0;
-    }
-
-    private static bool IsUnderNativeMenuEnvironment(Transform transform)
-    {
-        var current = transform;
-        while (current != null)
-        {
-            if (string.Equals(current.name, EnvironmentRootName, StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-
-            current = current.parent;
-        }
-
-        return false;
     }
 
     private static int GetTransformDepth(Transform transform)

--- a/NOVR/VrUi/Native/NativeMenuEnvironmentAssetCache.cs
+++ b/NOVR/VrUi/Native/NativeMenuEnvironmentAssetCache.cs
@@ -1,0 +1,837 @@
+using System;
+using System.Collections;
+using System.Reflection;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using Object = UnityEngine.Object;
+
+namespace NOVR.VrUi.Native;
+
+public sealed class NativeMenuEnvironmentAssetCache : MonoBehaviour
+{
+    private const string EncyclopediaSceneName = "Encyclopedia";
+    private const string EncyclopediaScenePath = "Assets/Scenes/Encyclopedia/Encyclopedia.unity";
+    private const string MainMenuSceneName = "MainMenu";
+    private const string MainMenuScenePath = "Assets/Scenes/MainMenu/MainMenu.unity";
+    private const float ScenePollIntervalSeconds = 0.5f;
+    private const float MenuWarmupDelayTimeoutSeconds = 8f;
+
+    private static readonly BindingFlags InstanceFields = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+
+    private Material? _waterMaterialTemplate;
+    private Texture2D? _menuOceanBasecolor;
+    private Texture2D? _oceanBasecolor;
+    private Texture2D? _oceanDepthmap;
+    private Texture2D? _terrainColorMap;
+    private Vector2 _mapSize;
+
+    private GameObject? _cloudPlaneTemplate;
+    private WeatherSet[] _weatherSets = Array.Empty<WeatherSet>();
+    private Material? _cloudLayerMaterialTemplate;
+    private Material? _cloudMaterialTemplate;
+    private Material? _distantCloudMaterialTemplate;
+    private Material? _flyThroughCloudMaterialTemplate;
+    private float _cloudDensityMapScale;
+    private float _cloudSizeMin;
+    private float _cloudSizeMax;
+    private float _cloudDrawDistance;
+    private int _cloudGenerationRate;
+    private int _cloudMaxParticles;
+    private int _cachedSceneHandle;
+    private int _pendingCacheSceneHandle;
+    private float _nextScenePollTime;
+    private float _nextMissingObjectDiagnosticTime;
+    private float _menuWarmupStartTime;
+    private bool _gameStateListenerRegistered;
+    private bool _menuWarmupStarted;
+    private bool _menuWarmupInProgress;
+    private bool _menuWarmupComplete;
+    private bool _menuWarmupFailed;
+    private bool _menuWarmupSceneLoadedByCache;
+    private Scene _menuWarmupScene;
+    private GameState _preWarmupGameState;
+
+    public static NativeMenuEnvironmentAssetCache? Instance { get; private set; }
+
+    public bool HasWaterMaterial => IsAlive(_waterMaterialTemplate);
+    public bool HasCloudPlane => IsAlive(_cloudPlaneTemplate);
+    public bool HasCloudMaterials => IsAlive(_cloudLayerMaterialTemplate) && IsAlive(_cloudMaterialTemplate);
+    public int CachedWeatherSetCount => _weatherSets.Length;
+    public bool ShouldDelayMenuEnvironment =>
+        _menuWarmupStarted &&
+        !_menuWarmupComplete &&
+        !_menuWarmupFailed &&
+        !HasCloudPlane &&
+        Time.unscaledTime - _menuWarmupStartTime < MenuWarmupDelayTimeoutSeconds;
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(this);
+            return;
+        }
+
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+        Debug.Log("[NOVR] Native menu environment asset cache ready.");
+    }
+
+    private void OnEnable()
+    {
+        SceneManager.sceneLoaded += OnSceneLoaded;
+        SceneManager.sceneUnloaded += OnSceneUnloaded;
+        RegisterGameStateListener();
+    }
+
+    private void OnDisable()
+    {
+        SceneManager.sceneLoaded -= OnSceneLoaded;
+        SceneManager.sceneUnloaded -= OnSceneUnloaded;
+        UnregisterGameStateListener();
+    }
+
+    private void OnDestroy()
+    {
+        if (Instance == this)
+        {
+            Instance = null;
+        }
+
+        DestroyCachedMaterial(ref _waterMaterialTemplate);
+        DestroyCachedTexture(ref _menuOceanBasecolor);
+        DestroyCachedMaterial(ref _cloudLayerMaterialTemplate);
+        DestroyCachedMaterial(ref _cloudMaterialTemplate);
+        DestroyCachedMaterial(ref _distantCloudMaterialTemplate);
+        DestroyCachedMaterial(ref _flyThroughCloudMaterialTemplate);
+        DestroyCachedGameObject(ref _cloudPlaneTemplate);
+    }
+
+    public bool TryCreateWaterMaterial(out Material? material)
+    {
+        material = null;
+        if (!IsAlive(_waterMaterialTemplate))
+        {
+            return false;
+        }
+
+        material = new Material(_waterMaterialTemplate)
+        {
+            name = "NOVR Menu Encyclopedia WaterMat",
+            hideFlags = HideFlags.DontSave
+        };
+
+        ApplyCachedWaterTextures(material);
+        return true;
+    }
+
+    public bool TryCreateCloudPlane(out GameObject? cloudPlane)
+    {
+        cloudPlane = null;
+        if (!IsAlive(_cloudPlaneTemplate))
+        {
+            return false;
+        }
+
+        var template = _cloudPlaneTemplate;
+        if (template == null)
+        {
+            return false;
+        }
+
+        cloudPlane = Object.Instantiate(template);
+        cloudPlane.hideFlags = HideFlags.DontSave;
+        return true;
+    }
+
+    public void EnsureMenuWarmupStarted()
+    {
+        if (_menuWarmupStarted || _menuWarmupComplete || _menuWarmupFailed || HasCloudPlane)
+        {
+            return;
+        }
+
+        if (!IsMainMenuLoaded())
+        {
+            return;
+        }
+
+        if (GameManager.gameState == GameState.SinglePlayer ||
+            GameManager.gameState == GameState.Multiplayer ||
+            GameManager.gameState == GameState.Editor ||
+            GameManager.gameState == GameState.Encyclopedia ||
+            GameManager.gameState == GameState.ServerWaiting)
+        {
+            return;
+        }
+
+        _menuWarmupStarted = true;
+        _menuWarmupInProgress = true;
+        _menuWarmupStartTime = Time.unscaledTime;
+        _preWarmupGameState = GameManager.gameState;
+        StartCoroutine(WarmMenuAssetsFromEncyclopediaScene());
+    }
+
+    private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
+    {
+        if (IsMainMenuScene(scene))
+        {
+            EnsureMenuWarmupStarted();
+        }
+
+        if (_menuWarmupInProgress && IsEncyclopediaScene(scene))
+        {
+            _menuWarmupScene = scene;
+            DisableWarmupSceneRoots(scene);
+        }
+
+        TryScheduleEncyclopediaCache(scene, "sceneLoaded");
+    }
+
+    private void RegisterGameStateListener()
+    {
+        if (_gameStateListenerRegistered) return;
+
+        GameManager.OnGameStateChanged.AddListener(OnGameStateChanged);
+        _gameStateListenerRegistered = true;
+    }
+
+    private void UnregisterGameStateListener()
+    {
+        if (!_gameStateListenerRegistered) return;
+
+        GameManager.OnGameStateChanged.RemoveListener(OnGameStateChanged);
+        _gameStateListenerRegistered = false;
+    }
+
+    private void OnGameStateChanged()
+    {
+        if (GameManager.gameState != GameState.Encyclopedia)
+        {
+            return;
+        }
+
+        Debug.Log($"[NOVR] Native menu environment asset cache observed Encyclopedia state; scenes={DescribeLoadedScenes()}.");
+        StartCoroutine(CacheAfterGameStateSettles());
+    }
+
+    private void OnSceneUnloaded(Scene scene)
+    {
+        if (!IsEncyclopediaScene(scene))
+        {
+            return;
+        }
+
+        if (_menuWarmupScene.handle == scene.handle)
+        {
+            _menuWarmupScene = default;
+            _menuWarmupSceneLoadedByCache = false;
+        }
+
+        if (_cachedSceneHandle == scene.handle)
+        {
+            _cachedSceneHandle = 0;
+        }
+
+        if (_pendingCacheSceneHandle == scene.handle)
+        {
+            _pendingCacheSceneHandle = 0;
+        }
+    }
+
+    private void Update()
+    {
+        if (Time.unscaledTime < _nextScenePollTime)
+        {
+            return;
+        }
+
+        _nextScenePollTime = Time.unscaledTime + ScenePollIntervalSeconds;
+        for (var index = 0; index < SceneManager.sceneCount; index++)
+        {
+            TryScheduleEncyclopediaCache(SceneManager.GetSceneAt(index), "poll");
+        }
+
+        EnsureMenuWarmupStarted();
+
+        if (GameManager.gameState == GameState.Encyclopedia)
+        {
+            TryCacheFromLiveObjects("live-object-poll");
+        }
+    }
+
+    private IEnumerator WarmMenuAssetsFromEncyclopediaScene()
+    {
+        Debug.Log("[NOVR] Native menu environment starting hidden Encyclopedia asset warmup.");
+
+        yield return null;
+
+        var scene = FindLoadedScene(EncyclopediaScenePath, EncyclopediaSceneName);
+        if (!scene.IsValid() || !scene.isLoaded)
+        {
+            AsyncOperation? loadOperation;
+            try
+            {
+                loadOperation = SceneManager.LoadSceneAsync(EncyclopediaScenePath, LoadSceneMode.Additive);
+            }
+            catch (Exception exception)
+            {
+                MarkMenuWarmupFailed($"could not start hidden Encyclopedia load: {exception.GetType().Name}: {exception.Message}");
+                yield break;
+            }
+
+            if (loadOperation == null)
+            {
+                MarkMenuWarmupFailed("SceneManager returned null for hidden Encyclopedia load.");
+                yield break;
+            }
+
+            _menuWarmupSceneLoadedByCache = true;
+            while (!loadOperation.isDone)
+            {
+                yield return null;
+            }
+
+            scene = FindLoadedScene(EncyclopediaScenePath, EncyclopediaSceneName);
+        }
+
+        if (!scene.IsValid() || !scene.isLoaded)
+        {
+            MarkMenuWarmupFailed("hidden Encyclopedia scene load finished without a valid scene.");
+            yield break;
+        }
+
+        _menuWarmupScene = scene;
+        DisableWarmupSceneRoots(scene);
+        CacheFromEncyclopediaScene(scene, "hidden-menu-warmup");
+
+        if (!HasCloudPlane)
+        {
+            TryCacheFromLiveObjects("hidden-menu-warmup-live");
+        }
+
+        if (_menuWarmupSceneLoadedByCache && scene.IsValid() && scene.isLoaded)
+        {
+            var unloadOperation = SceneManager.UnloadSceneAsync(scene);
+            if (unloadOperation != null)
+            {
+                while (!unloadOperation.isDone)
+                {
+                    yield return null;
+                }
+            }
+        }
+
+        RestoreGameStateAfterWarmup();
+
+        _menuWarmupInProgress = false;
+        _menuWarmupComplete = HasCloudPlane;
+        _menuWarmupFailed = !_menuWarmupComplete;
+        Debug.Log(
+            "[NOVR] Native menu environment hidden Encyclopedia asset warmup finished: " +
+            $"cloudPlane={HasCloudPlane}, waterMaterial={HasWaterMaterial}, weatherSets={_weatherSets.Length}, failed={_menuWarmupFailed}.");
+    }
+
+    private void MarkMenuWarmupFailed(string reason)
+    {
+        RestoreGameStateAfterWarmup();
+        _menuWarmupInProgress = false;
+        _menuWarmupComplete = false;
+        _menuWarmupFailed = true;
+        Debug.LogWarning($"[NOVR] Native menu environment hidden Encyclopedia asset warmup failed: {reason}");
+    }
+
+    private void RestoreGameStateAfterWarmup()
+    {
+        if (GameManager.gameState != GameState.Encyclopedia)
+        {
+            return;
+        }
+
+        var restoreState = _preWarmupGameState == GameState.Uninitialized
+            ? GameState.Menu
+            : _preWarmupGameState;
+        GameManager.SetGameState(restoreState);
+        Debug.Log($"[NOVR] Native menu environment restored game state to {restoreState} after hidden asset warmup.");
+    }
+
+    private IEnumerator CacheAfterGameStateSettles()
+    {
+        yield return null;
+        yield return null;
+        yield return null;
+
+        TryCacheFromLiveObjects("game-state");
+    }
+
+    private void TryScheduleEncyclopediaCache(Scene scene, string trigger)
+    {
+        if (!IsEncyclopediaScene(scene) || !scene.isLoaded)
+        {
+            return;
+        }
+
+        if (_cachedSceneHandle == scene.handle || _pendingCacheSceneHandle == scene.handle)
+        {
+            return;
+        }
+
+        _pendingCacheSceneHandle = scene.handle;
+        StartCoroutine(CacheAfterSceneSettles(scene, trigger));
+    }
+
+    private IEnumerator CacheAfterSceneSettles(Scene scene, string trigger)
+    {
+        yield return null;
+        yield return null;
+        yield return null;
+
+        if (!scene.IsValid() || !scene.isLoaded)
+        {
+            if (_pendingCacheSceneHandle == scene.handle)
+            {
+                _pendingCacheSceneHandle = 0;
+            }
+
+            yield break;
+        }
+
+        CacheFromEncyclopediaScene(scene, trigger);
+        _cachedSceneHandle = scene.handle;
+        if (_pendingCacheSceneHandle == scene.handle)
+        {
+            _pendingCacheSceneHandle = 0;
+        }
+    }
+
+    private void CacheFromEncyclopediaScene(Scene scene, string trigger)
+    {
+        CacheFromObjects(
+            FindSceneComponent<MapSettings>(scene),
+            FindSceneComponent<LevelInfo>(scene),
+            FindSceneComponent<CloudLayer>(scene),
+            trigger);
+    }
+
+    private void TryCacheFromLiveObjects(string trigger)
+    {
+        if (HasWaterMaterial && HasCloudMaterials && _weatherSets.Length > 0)
+        {
+            return;
+        }
+
+        var mapSettings = FindBestLoadedMapSettings();
+        var levelInfo = FindBestLoadedObject<LevelInfo>("LevelInfo");
+        var cloudLayer = FindBestLoadedObject<CloudLayer>("cloudPlane");
+        if (mapSettings == null && levelInfo == null && cloudLayer == null)
+        {
+            LogMissingObjectDiagnostic(trigger);
+            return;
+        }
+
+        CacheFromObjects(mapSettings, levelInfo, cloudLayer, trigger);
+    }
+
+    private void CacheFromObjects(MapSettings? mapSettings, LevelInfo? levelInfo, CloudLayer? cloudLayer, string trigger)
+    {
+        if (mapSettings != null)
+        {
+            _mapSize = mapSettings.MapSize;
+            _oceanBasecolor = mapSettings.OceanBasecolor;
+            _oceanDepthmap = mapSettings.OceanDepthmap;
+            _terrainColorMap = mapSettings.TerrainColorMap;
+        }
+
+        var waterMaterial = GetFieldValue<Material>(levelInfo, "waterMaterial");
+        ReplaceMaterialTemplate(ref _waterMaterialTemplate, waterMaterial, "NOVR Cached Encyclopedia WaterMat");
+        if (_waterMaterialTemplate != null)
+        {
+            ApplyCachedWaterTextures(_waterMaterialTemplate);
+        }
+
+        CacheCloudLayer(cloudLayer);
+
+        Debug.Log(
+            $"[NOVR] Native menu environment cached Encyclopedia assets via {trigger}: " +
+            $"waterMaterial={Describe(_waterMaterialTemplate)}, " +
+            $"oceanBasecolor={Describe(_oceanBasecolor)}, " +
+            $"oceanDepthmap={Describe(_oceanDepthmap)}, " +
+            $"terrainColorMap={Describe(_terrainColorMap)}, " +
+            $"weatherSets={_weatherSets.Length}, " +
+            $"cloudLayerMaterial={Describe(_cloudLayerMaterialTemplate)}, " +
+            $"cloudMaterial={Describe(_cloudMaterialTemplate)}, " +
+            $"distantCloudMaterial={Describe(_distantCloudMaterialTemplate)}, " +
+            $"flyThroughCloudMaterial={Describe(_flyThroughCloudMaterialTemplate)}, " +
+            $"cloudDensityScale={_cloudDensityMapScale}, " +
+            $"cloudSize={_cloudSizeMin}-{_cloudSizeMax}, " +
+            $"cloudDrawDist={_cloudDrawDistance}, " +
+            $"cloudGenerationRate={_cloudGenerationRate}, " +
+            $"cloudMaxParticles={_cloudMaxParticles}.");
+    }
+
+    private static bool IsEncyclopediaScene(Scene scene)
+    {
+        return scene.IsValid() &&
+               (string.Equals(scene.name, EncyclopediaSceneName, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(scene.path, EncyclopediaScenePath, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static bool IsMainMenuScene(Scene scene)
+    {
+        return scene.IsValid() &&
+               (string.Equals(scene.name, MainMenuSceneName, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(scene.path, MainMenuScenePath, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static bool IsMainMenuLoaded()
+    {
+        return FindLoadedScene(MainMenuScenePath, MainMenuSceneName).IsValid();
+    }
+
+    private static Scene FindLoadedScene(string scenePath, string sceneName)
+    {
+        for (var index = 0; index < SceneManager.sceneCount; index++)
+        {
+            var scene = SceneManager.GetSceneAt(index);
+            if (!scene.IsValid() || !scene.isLoaded)
+            {
+                continue;
+            }
+
+            if (string.Equals(scene.path, scenePath, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(scene.name, sceneName, StringComparison.OrdinalIgnoreCase))
+            {
+                return scene;
+            }
+        }
+
+        return default;
+    }
+
+    private static void DisableWarmupSceneRoots(Scene scene)
+    {
+        if (!scene.IsValid() || !scene.isLoaded)
+        {
+            return;
+        }
+
+        var roots = scene.GetRootGameObjects();
+        for (var index = 0; index < roots.Length; index++)
+        {
+            var root = roots[index];
+            if (root != null && root.activeSelf)
+            {
+                root.SetActive(false);
+            }
+        }
+    }
+
+    private void LogMissingObjectDiagnostic(string trigger)
+    {
+        if (Time.unscaledTime < _nextMissingObjectDiagnosticTime)
+        {
+            return;
+        }
+
+        _nextMissingObjectDiagnosticTime = Time.unscaledTime + 2f;
+        Debug.Log(
+            $"[NOVR] Native menu environment asset cache waiting for Encyclopedia objects via {trigger}: " +
+            $"mapSettings={Resources.FindObjectsOfTypeAll<MapSettings>().Length}, " +
+            $"levelInfo={Resources.FindObjectsOfTypeAll<LevelInfo>().Length}, " +
+            $"cloudLayer={Resources.FindObjectsOfTypeAll<CloudLayer>().Length}, " +
+            $"scenes={DescribeLoadedScenes()}.");
+    }
+
+    private static string DescribeLoadedScenes()
+    {
+        var descriptions = new string[SceneManager.sceneCount];
+        for (var index = 0; index < SceneManager.sceneCount; index++)
+        {
+            var scene = SceneManager.GetSceneAt(index);
+            descriptions[index] = $"'{scene.name}' path='{scene.path}' loaded={scene.isLoaded}";
+        }
+
+        return string.Join("; ", descriptions);
+    }
+
+    private void CacheCloudLayer(CloudLayer? cloudLayer)
+    {
+        if (cloudLayer == null)
+        {
+            _weatherSets = Array.Empty<WeatherSet>();
+            return;
+        }
+
+        ReplaceCloudPlaneTemplate(cloudLayer.gameObject);
+        _weatherSets = GetFieldValue<WeatherSet[]>(cloudLayer, "weatherSets") ?? Array.Empty<WeatherSet>();
+        ReplaceMaterialTemplate(ref _cloudLayerMaterialTemplate, GetFieldValue<Material>(cloudLayer, "layerMaterial"), "NOVR Cached Cloudlayer");
+        ReplaceMaterialTemplate(ref _cloudMaterialTemplate, GetFieldValue<Material>(cloudLayer, "cloudMaterial"), "NOVR Cached MeshCloud");
+        ReplaceMaterialTemplate(ref _distantCloudMaterialTemplate, GetFieldValue<Material>(cloudLayer, "distantCloudMaterial"), "NOVR Cached MeshCloud Distant");
+        ReplaceMaterialTemplate(ref _flyThroughCloudMaterialTemplate, GetFieldValue<Material>(cloudLayer, "flyThroughMaterial"), "NOVR Cached MeshCloud Close");
+
+        _cloudDensityMapScale = GetFieldValue<float>(cloudLayer, "densityMapScale");
+        _cloudSizeMin = GetFieldValue<float>(cloudLayer, "cloudSizeMin");
+        _cloudSizeMax = GetFieldValue<float>(cloudLayer, "cloudSizeMax");
+        _cloudDrawDistance = GetFieldValue<float>(cloudLayer, "cloudDrawDist");
+        _cloudGenerationRate = GetFieldValue<int>(cloudLayer, "generationRate");
+        _cloudMaxParticles = GetFieldValue<int>(cloudLayer, "maxParticles");
+    }
+
+    private void ApplyCachedWaterTextures(Material material)
+    {
+        var basecolor = GetMenuOceanBasecolorTexture();
+        SetMaterialTexture(material, "_macro_basecolor", basecolor);
+        SetMaterialTexture(material, "_macro_depth", _oceanDepthmap);
+        SetMaterialTexture(material, "_BaseMap", basecolor);
+        SetMaterialTexture(material, "_MainTex", basecolor);
+
+        if (material.HasProperty("_size"))
+        {
+            material.SetVector("_size", new Vector4(_mapSize.x, _mapSize.y, 0f, 0f));
+        }
+
+        if (material.HasProperty("_OriginOffset"))
+        {
+            material.SetVector("_OriginOffset", Vector4.zero);
+        }
+    }
+
+    private Texture2D GetMenuOceanBasecolorTexture()
+    {
+        if (_menuOceanBasecolor != null)
+        {
+            return _menuOceanBasecolor;
+        }
+
+        const int size = 128;
+        var texture = new Texture2D(size, size, TextureFormat.RGBA32, true)
+        {
+            name = "NOVR Menu Deep Ocean Basecolor",
+            wrapMode = TextureWrapMode.Repeat,
+            filterMode = FilterMode.Trilinear,
+            anisoLevel = 4,
+            hideFlags = HideFlags.HideAndDontSave
+        };
+
+        var deep = new Color(0.025f, 0.15f, 0.28f, 1f);
+        var mid = new Color(0.04f, 0.22f, 0.36f, 1f);
+        var highlight = new Color(0.065f, 0.31f, 0.46f, 1f);
+
+        for (var y = 0; y < size; y++)
+        {
+            for (var x = 0; x < size; x++)
+            {
+                var broad = Mathf.PerlinNoise(x * 0.035f, y * 0.035f);
+                var fine = Mathf.PerlinNoise(x * 0.12f + 17.3f, y * 0.12f + 42.1f);
+                var wave = Mathf.Sin((x * 0.12f) + (y * 0.05f)) * 0.08f;
+                var t = Mathf.Clamp01(0.18f + broad * 0.52f + fine * 0.16f + wave);
+                var color = t < 0.58f
+                    ? Color.Lerp(deep, mid, t / 0.58f)
+                    : Color.Lerp(mid, highlight, (t - 0.58f) / 0.42f);
+                texture.SetPixel(x, y, color);
+            }
+        }
+
+        texture.Apply(true, true);
+        _menuOceanBasecolor = texture;
+        return texture;
+    }
+
+    private static void SetMaterialTexture(Material material, string propertyName, Texture? texture)
+    {
+        if (texture != null && material.HasProperty(propertyName))
+        {
+            material.SetTexture(propertyName, texture);
+        }
+    }
+
+    private void ReplaceCloudPlaneTemplate(GameObject? source)
+    {
+        if (source == null)
+        {
+            return;
+        }
+
+        DestroyCachedGameObject(ref _cloudPlaneTemplate);
+        _cloudPlaneTemplate = InstantiateInactive(source);
+        _cloudPlaneTemplate.name = "NOVR Cached Encyclopedia cloudPlane";
+        _cloudPlaneTemplate.hideFlags = HideFlags.HideAndDontSave;
+        _cloudPlaneTemplate.transform.SetParent(transform, false);
+        _cloudPlaneTemplate.SetActive(false);
+        StripCloudLayerComponents(_cloudPlaneTemplate);
+    }
+
+    private static GameObject InstantiateInactive(GameObject source)
+    {
+        var wasActive = source.activeSelf;
+        source.SetActive(false);
+        try
+        {
+            return Object.Instantiate(source);
+        }
+        finally
+        {
+            source.SetActive(wasActive);
+        }
+    }
+
+    private static void StripCloudLayerComponents(GameObject root)
+    {
+        var components = root.GetComponentsInChildren<MonoBehaviour>(true);
+        for (var index = 0; index < components.Length; index++)
+        {
+            var component = components[index];
+            if (component == null ||
+                !string.Equals(component.GetType().Name, "CloudLayer", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            Object.DestroyImmediate(component);
+        }
+    }
+
+    private static void ReplaceMaterialTemplate(ref Material? target, Material? source, string name)
+    {
+        if (source == null)
+        {
+            return;
+        }
+
+        DestroyCachedMaterial(ref target);
+        target = new Material(source)
+        {
+            name = name,
+            hideFlags = HideFlags.HideAndDontSave
+        };
+    }
+
+    private static void DestroyCachedMaterial(ref Material? material)
+    {
+        if (material == null)
+        {
+            return;
+        }
+
+        Object.Destroy(material);
+        material = null;
+    }
+
+    private static void DestroyCachedTexture(ref Texture2D? texture)
+    {
+        if (texture == null)
+        {
+            return;
+        }
+
+        Object.Destroy(texture);
+        texture = null;
+    }
+
+    private static void DestroyCachedGameObject(ref GameObject? gameObject)
+    {
+        if (gameObject == null)
+        {
+            return;
+        }
+
+        Object.Destroy(gameObject);
+        gameObject = null;
+    }
+
+    private static T? FindSceneComponent<T>(Scene scene) where T : Component
+    {
+        if (!scene.IsValid() || !scene.isLoaded)
+        {
+            return null;
+        }
+
+        var roots = scene.GetRootGameObjects();
+        for (var rootIndex = 0; rootIndex < roots.Length; rootIndex++)
+        {
+            var root = roots[rootIndex];
+            if (root == null) continue;
+
+            var components = root.GetComponentsInChildren<T>(true);
+            for (var index = 0; index < components.Length; index++)
+            {
+                if (components[index] != null)
+                {
+                    return components[index];
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static MapSettings? FindBestLoadedMapSettings()
+    {
+        var mapSettings = Resources.FindObjectsOfTypeAll<MapSettings>();
+        MapSettings? fallback = null;
+        for (var index = 0; index < mapSettings.Length; index++)
+        {
+            var candidate = mapSettings[index];
+            if (candidate == null) continue;
+
+            fallback ??= candidate;
+            if (candidate.OceanBasecolor != null || candidate.OceanDepthmap != null)
+            {
+                return candidate;
+            }
+        }
+
+        return fallback;
+    }
+
+    private static T? FindBestLoadedObject<T>(string preferredName) where T : Component
+    {
+        var objects = Resources.FindObjectsOfTypeAll<T>();
+        T? fallback = null;
+        for (var index = 0; index < objects.Length; index++)
+        {
+            var candidate = objects[index];
+            if (candidate == null) continue;
+
+            fallback ??= candidate;
+            if (string.Equals(candidate.name, preferredName, StringComparison.OrdinalIgnoreCase))
+            {
+                return candidate;
+            }
+        }
+
+        return fallback;
+    }
+
+    private static T? GetFieldValue<T>(object? source, string fieldName)
+    {
+        if (source == null)
+        {
+            return default;
+        }
+
+        var field = source.GetType().GetField(fieldName, InstanceFields);
+        if (field == null)
+        {
+            return default;
+        }
+
+        var value = field.GetValue(source);
+        return value is T typed ? typed : default;
+    }
+
+    private static bool IsAlive(Object? obj)
+    {
+        return obj != null;
+    }
+
+    private static string Describe(Object? obj)
+    {
+        if (obj == null)
+        {
+            return "null";
+        }
+
+        return $"{obj.GetType().Name} '{obj.name}'";
+    }
+}

--- a/NOVR/VrUi/Native/NativeMultiplayerPanel.cs
+++ b/NOVR/VrUi/Native/NativeMultiplayerPanel.cs
@@ -48,6 +48,7 @@ public class NativeMultiplayerPanel : MonoBehaviour
     private readonly List<Text> _hostMissionButtonTexts = new();
 
     private NativeGameActionAdapter? _actions;
+    private Action? _missionLaunchStarted;
     private RectTransform? _container;
     private RectTransform? _browserListPanel;
     private RectTransform? _detailsPanel;
@@ -102,9 +103,10 @@ public class NativeMultiplayerPanel : MonoBehaviour
     private float _nextSourceRefreshTime;
     private bool _wasVisible;
 
-    public void Initialize(NativeGameActionAdapter actions, RectTransform root)
+    public void Initialize(NativeGameActionAdapter actions, RectTransform root, Action missionLaunchStarted)
     {
         _actions = actions;
+        _missionLaunchStarted = missionLaunchStarted;
         _font = Resources.GetBuiltinResource<Font>("Arial.ttf");
         BuildLayout(root);
     }
@@ -960,6 +962,7 @@ public class NativeMultiplayerPanel : MonoBehaviour
                 MaxConnections = maxPlayers - 1,
                 Password = hasPassword ? password : null
             };
+            _missionLaunchStarted?.Invoke();
             await NetworkManagerNuclearOption.i.StartHostAsync(options);
         }
         catch (Exception exception)
@@ -1019,6 +1022,7 @@ public class NativeMultiplayerPanel : MonoBehaviour
 
         if (_actions?.TryJoinLobby(lobby.Lobby, null, promptIfPasswordNeeded: false) == true)
         {
+            _missionLaunchStarted?.Invoke();
             SetStatus($"Joining {lobby.LobbyName}.");
         }
         else
@@ -1091,6 +1095,7 @@ public class NativeMultiplayerPanel : MonoBehaviour
         HidePasswordPanel();
         if (_actions?.TryJoinLobby(lobby.Lobby, password, promptIfPasswordNeeded: false) == true)
         {
+            _missionLaunchStarted?.Invoke();
             SetStatus($"Joining {lobby.LobbyName}.");
         }
         else

--- a/NOVR/VrUi/Native/NativeSinglePlayerMissionPanel.cs
+++ b/NOVR/VrUi/Native/NativeSinglePlayerMissionPanel.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NuclearOption.Networking;
@@ -31,6 +32,7 @@ public class NativeSinglePlayerMissionPanel : MonoBehaviour
     private readonly List<TagFilterDefinition> _tagFilters = new();
 
     private NativeGameActionAdapter? _actions;
+    private Action? _missionLaunchStarted;
     private RectTransform? _container;
     private Font? _font;
     private Text? _titleText;
@@ -45,9 +47,10 @@ public class NativeSinglePlayerMissionPanel : MonoBehaviour
     private int _activeTagFilterIndex;
     private bool _loaded;
 
-    public void Initialize(NativeGameActionAdapter actions, RectTransform root)
+    public void Initialize(NativeGameActionAdapter actions, RectTransform root, Action missionLaunchStarted)
     {
         _actions = actions;
+        _missionLaunchStarted = missionLaunchStarted;
         _font = Resources.GetBuiltinResource<Font>("Arial.ttf");
         BuildLayout(root);
     }
@@ -348,6 +351,7 @@ public class NativeSinglePlayerMissionPanel : MonoBehaviour
         }
 
         MissionManager.SetMission(mission, checkIfSame: false);
+        _missionLaunchStarted?.Invoke();
         NetworkManagerNuclearOption.i.StartHost(new HostOptions(SocketType.Offline, GameState.SinglePlayer, mission.MapKey));
     }
 

--- a/NOVR/VrUi/Native/NativeVrUiRoot.cs
+++ b/NOVR/VrUi/Native/NativeVrUiRoot.cs
@@ -1,5 +1,6 @@
 using NOVR.VrUi.SpecialBehavior;
 using System.Collections.Generic;
+using NuclearOption.Networking;
 using NuclearOption.Networking.Lobbies;
 using NuclearOption.Workshop;
 using UnityEngine;
@@ -17,6 +18,7 @@ public class NativeVrUiRoot : NOVRBehaviour
     private static readonly Vector2 NativeCanvasSize = new(2000f, 1125f);
     private const float MainMenuScanIntervalSeconds = 0.5f;
     private const float RequestedMenuTransitionSeconds = 0.5f;
+    private const float MissionLaunchEnvironmentSuppressionSeconds = 8f;
     private const float RecenterDelaySeconds = 2.0f;
     private const float AnchorResetAfterHiddenSeconds = 1.5f;
     private const float MinimumMenuCenterHeightBelowHeadMeters = -0.25f;
@@ -58,6 +60,8 @@ public class NativeVrUiRoot : NOVRBehaviour
     private bool _workshopRequested;
     private float _workshopRequestTime;
     private bool _vrUiSettingsOpen;
+    private bool _missionLaunchPending;
+    private float _missionLaunchRequestTime;
     private float _nextMainMenuScanTime;
     private float _pendingRecenterTime;
     private bool _recenterPending;
@@ -80,6 +84,25 @@ public class NativeVrUiRoot : NOVRBehaviour
         _pointerState.Update(VrUiCursor.I);
         EnsureRoot();
         ScanForMainMenuCanvas();
+
+        if (GameManager.gameState != GameState.Menu)
+        {
+            RestoreOriginalMainCanvas();
+            if (_root != null)
+            {
+                _root.SetActive(false);
+            }
+            _menuEnvironment?.Hide();
+            ClearNativeCursorProjectionReference();
+            SetUtilityWidgetMode(UtilityWidgetMode.Hidden);
+            return;
+        }
+
+        if (_missionLaunchPending &&
+            Time.unscaledTime - _missionLaunchRequestTime > MissionLaunchEnvironmentSuppressionSeconds)
+        {
+            _missionLaunchPending = false;
+        }
 
         if (!IsNativeMenuUiEnabled)
         {
@@ -161,6 +184,18 @@ public class NativeVrUiRoot : NOVRBehaviour
         _vrUiSettingsPanel?.SetVisible(shouldShowVrUiSettings);
 
         var shouldShowNativeUi = shouldShowMainMenu || shouldShowSinglePlayerMissionPicker || shouldShowMultiplayer || shouldShowSettings || shouldShowWorkshop || shouldShowVrUiSettings;
+        var shouldKeepEnvironmentForMenuTransition = !controlMapperOpen &&
+                                                     (waitingForSinglePlayerMissionPicker ||
+                                                      waitingForMultiplayer ||
+                                                      waitingForSettingsMenu ||
+                                                      waitingForWorkshop ||
+                                                      _singlePlayerMissionPickerRequested ||
+                                                      _multiplayerRequested ||
+                                                      _settingsRequested ||
+                                                      _workshopRequested ||
+                                                      _vrUiSettingsOpen);
+        var shouldShowNativeEnvironment = !_missionLaunchPending &&
+                                          (shouldShowNativeUi || shouldKeepEnvironmentForMenuTransition);
         HandleRecenterShortcut(shouldShowNativeUi);
         UpdatePlacement(shouldShowNativeUi);
         UpdatePendingRecenter(shouldShowNativeUi);
@@ -171,7 +206,7 @@ public class NativeVrUiRoot : NOVRBehaviour
 
         if (_root != null)
         {
-            _menuEnvironment?.UpdateEnvironment(_root.transform, shouldShowNativeUi);
+            _menuEnvironment?.UpdateEnvironment(_root.transform, shouldShowNativeEnvironment);
         }
 
         SuppressOriginalMainCanvas(shouldShowNativeUi);
@@ -224,10 +259,10 @@ public class NativeVrUiRoot : NOVRBehaviour
         _mainMenuShell.Initialize(_actions, rectTransform, OpenVrUiSettingsPanel);
         _mainMenuShell.SetOriginalMainCanvas(_mainCanvas);
         _multiplayerPanel = _root.AddComponent<NativeMultiplayerPanel>();
-        _multiplayerPanel.Initialize(_actions, rectTransform);
+        _multiplayerPanel.Initialize(_actions, rectTransform, OnMissionLaunchRequested);
         _multiplayerPanel.SetVisible(false);
         _singlePlayerMissionPanel = _root.AddComponent<NativeSinglePlayerMissionPanel>();
-        _singlePlayerMissionPanel.Initialize(_actions, rectTransform);
+        _singlePlayerMissionPanel.Initialize(_actions, rectTransform, OnMissionLaunchRequested);
         _singlePlayerMissionPanel.SetVisible(false);
         _settingsPanel = _root.AddComponent<NativeSettingsPanel>();
         _settingsPanel.Initialize(_actions, rectTransform);
@@ -740,6 +775,13 @@ public class NativeVrUiRoot : NOVRBehaviour
     {
         _vrUiSettingsOpen = false;
         _vrUiSettingsPanel?.SetVisible(false);
+    }
+
+    private void OnMissionLaunchRequested()
+    {
+        _missionLaunchPending = true;
+        _missionLaunchRequestTime = Time.unscaledTime;
+        _menuEnvironment?.Hide();
     }
 
     private void ShowSinglePlayerMissionPanelImmediately()


### PR DESCRIPTION
## Changelog

### Added
- Added a dedicated native 3D menu environment scene path for the VR menu.
- Added hidden Encyclopedia asset warmup/cache so menu clouds and water assets can be cloned without showing the Encyclopedia scene to the user.
- Added cached cloud-plane support with menu-scoped cloud material/particle tuning.
- Added cached Encyclopedia water material support with a deeper ocean-blue menu tint.
- Added menu-only frigate wake tuning for `wakefoam`, `bowFoam`, `thrusterSprayR`, and `thrusterMistR`.
- Added a menu-only hangar door animator for `frigate1_hangarDoor`.

### Changed
- Preserved the 3D menu environment across Single Player / Multiplayer menu scene transitions so it no longer resets when navigating those menus.
- Kept the environment hidden/destroyed when launching an actual mission.
- Scoped menu render settings so ambient/fog changes are restored before gameplay.
- Disabled unnecessary preview frigate hull parts that are out of view.
- Disabled Attack Helo navlights and spotlights in the menu preview.

### Fixed
- Fixed menu render settings carrying into gameplay.
- Fixed environment disappearing or resetting during SP/MP menu navigation.
- Fixed clouds being unavailable unless the Encyclopedia scene had been loaded manually.
- Removed reliance on the previous visible scene warmup behavior.

### Validation
- Built successfully in Release.
- Deployed locally for in-game testing.
- Verified gameplay lighting/fog remains normal after mission load.
- Verified menu environment persists through SP/MP browsing and cleans up on mission launch.