### PR TITLE
Add configurable recenter shortcut with live-recenter support for mis…

### DIFF
--- a/NOVR/Core.cs
+++ b/NOVR/Core.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using NOVR.VrCamera;
 using NOVR.VrTogglers;
 using NOVR.VrUi;
@@ -24,6 +25,8 @@ public class Core : MonoBehaviour
     
     private Aircraft _aircraft;
     private Aircraft _oldAircraft;
+
+    public static string CurrentAircraftId { get; private set; }
 
     public static void Create()
     {
@@ -122,8 +125,23 @@ public class Core : MonoBehaviour
     {
         _oldAircraft = _aircraft;
         GameManager.GetLocalAircraft(out _aircraft);
-        if (_aircraft != _oldAircraft) NOVRHeadsetData.CalibrateTranslation();
+        if (_aircraft != _oldAircraft)
+        {
+            CurrentAircraftId = ResolveAircraftId(_aircraft);
+            if (ModConfiguration.Instance.TryGetSavedOffset(CurrentAircraftId, out var f, out var r))
+            {
+                ModConfiguration.Instance.CockpitHeadForwardOffset.Value = f;
+                ModConfiguration.Instance.CockpitHeadRightOffset.Value = r;
+            }
+            NOVRHeadsetData.CalibrateTranslation();
+        }
         CameraStateManager.enableMouseLook = false;
+    }
+
+    private static string ResolveAircraftId(Aircraft aircraft)
+    {
+        if (aircraft == null || aircraft.definition == null) return null;
+        return Regex.Replace(aircraft.definition.name, "[^a-zA-Z0-9_]", "_");
     }
 
 }

--- a/NOVR/ModConfiguration.cs
+++ b/NOVR/ModConfiguration.cs
@@ -19,6 +19,8 @@ public class ModConfiguration
     public readonly ConfigEntry<bool> EnableExperimentalSteamVrControllerProfiles;
     public readonly ConfigEntry<bool> LogXrStartupDiagnostics;
     public readonly ConfigEntry<float> CockpitHeadForwardOffset;
+    public readonly ConfigEntry<float> CockpitHeadRightOffset;
+    public readonly ConfigEntry<KeyCode> RecenterShortcut;
 
     public ModConfiguration(ConfigFile config)
     {
@@ -78,5 +80,17 @@ public class ModConfiguration
             "Cockpit Head Forward Offset",
             0.05f,
             "Offset in meters applied to the cockpit head forward vector. Helps keep the ejection seat bars out of your face.");
+
+        CockpitHeadRightOffset = config.Bind(
+            "Experimental",
+            "Cockpit Head Right Offset",
+            0.0f,
+            "Offset in meters applied to the cockpit head right vector. Moves you left (negative) or right (positive) to correct off-center seating.");
+
+        RecenterShortcut = config.Bind(
+            "Input",
+            "Recenter Shortcut",
+            KeyCode.F9,
+            "Keyboard shortcut to recenter the VR view. For HOTAS users, map a joystick button to this key via external software.");
     }
 }

--- a/NOVR/ModConfiguration.cs
+++ b/NOVR/ModConfiguration.cs
@@ -1,4 +1,6 @@
-﻿using System.ComponentModel;
+﻿using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
 using BepInEx.Configuration;
 using UnityEngine;
 
@@ -21,6 +23,9 @@ public class ModConfiguration
     public readonly ConfigEntry<float> CockpitHeadForwardOffset;
     public readonly ConfigEntry<float> CockpitHeadRightOffset;
     public readonly ConfigEntry<KeyCode> RecenterShortcut;
+    public readonly ConfigEntry<bool> SavePositionTrigger;
+
+    private readonly Dictionary<string, (ConfigEntry<float> Forward, ConfigEntry<float> Right)> _perPlaneEntries = new();
 
     public ModConfiguration(ConfigFile config)
     {
@@ -92,5 +97,102 @@ public class ModConfiguration
             "Recenter Shortcut",
             KeyCode.F9,
             "Keyboard shortcut to recenter the VR view. For HOTAS users, map a joystick button to this key via external software.");
+
+        SavePositionTrigger = config.Bind(
+            "Experimental",
+            "Save Position For Current Aircraft",
+            false,
+            "Check this box to save the current Cockpit Head Forward/Right Offset values for the aircraft you're currently in. Automatically unchecks itself.");
+
+        SavePositionTrigger.SettingChanged += (_, _) =>
+        {
+            if (!SavePositionTrigger.Value) return;
+            SavePositionTrigger.Value = false;
+
+            if (string.IsNullOrEmpty(Core.CurrentAircraftId))
+            {
+                Debug.LogWarning("[NOVR] Cannot save cockpit offset: no aircraft is currently active.");
+                return;
+            }
+
+            SaveCurrentOffsetFor(Core.CurrentAircraftId, CockpitHeadForwardOffset.Value, CockpitHeadRightOffset.Value);
+        };
+
+        PreloadPerPlaneEntries();
+    }
+
+    private void PreloadPerPlaneEntries()
+    {
+        if (!File.Exists(Config.ConfigFilePath)) return;
+
+        var inPerPlaneSection = false;
+        foreach (var rawLine in File.ReadAllLines(Config.ConfigFilePath))
+        {
+            var line = rawLine.Trim();
+            if (line.StartsWith("[") && line.EndsWith("]"))
+            {
+                inPerPlaneSection = line.Equals("[PerPlaneOffsets]");
+                continue;
+            }
+
+            if (!inPerPlaneSection) continue;
+
+            var equalsIndex = line.IndexOf('=');
+            if (equalsIndex <= 0) continue;
+
+            var key = line.Substring(0, equalsIndex).Trim();
+            if (key.EndsWith("_Forward"))
+            {
+                GetOrCreatePlaneEntries(key.Substring(0, key.Length - "_Forward".Length));
+            }
+            else if (key.EndsWith("_Right"))
+            {
+                GetOrCreatePlaneEntries(key.Substring(0, key.Length - "_Right".Length));
+            }
+        }
+    }
+
+    private (ConfigEntry<float> Forward, ConfigEntry<float> Right) GetOrCreatePlaneEntries(string aircraftId)
+    {
+        if (_perPlaneEntries.TryGetValue(aircraftId, out var entries)) return entries;
+
+        var forward = Config.Bind(
+            "PerPlaneOffsets",
+            $"{aircraftId}_Forward",
+            float.NaN,
+            "Saved Cockpit Head Forward Offset for this aircraft type. NaN means no value has been saved yet.");
+
+        var right = Config.Bind(
+            "PerPlaneOffsets",
+            $"{aircraftId}_Right",
+            float.NaN,
+            "Saved Cockpit Head Right Offset for this aircraft type. NaN means no value has been saved yet.");
+
+        entries = (forward, right);
+        _perPlaneEntries[aircraftId] = entries;
+        return entries;
+    }
+
+    public bool TryGetSavedOffset(string aircraftId, out float forward, out float right)
+    {
+        forward = 0f;
+        right = 0f;
+        if (string.IsNullOrEmpty(aircraftId)) return false;
+
+        var entries = GetOrCreatePlaneEntries(aircraftId);
+        if (float.IsNaN(entries.Forward.Value) || float.IsNaN(entries.Right.Value)) return false;
+
+        forward = entries.Forward.Value;
+        right = entries.Right.Value;
+        return true;
+    }
+
+    public void SaveCurrentOffsetFor(string aircraftId, float forward, float right)
+    {
+        if (string.IsNullOrEmpty(aircraftId)) return;
+
+        var entries = GetOrCreatePlaneEntries(aircraftId);
+        entries.Forward.Value = forward;
+        entries.Right.Value = right;
     }
 }

--- a/NOVR/NOVRHeadsetData.cs
+++ b/NOVR/NOVRHeadsetData.cs
@@ -41,7 +41,8 @@ public class NOVRHeadsetData : NOVRBehaviour
             (calibrationAxes & CalibrationAxes.X) != 0 ? currentError.x : ov ? TranslationCalibrationOffset.x : 0,
             (calibrationAxes & CalibrationAxes.Y) != 0 ? currentError.y : ov ? TranslationCalibrationOffset.y : 0,
             (calibrationAxes & CalibrationAxes.Z) != 0 ? currentError.z : ov ? TranslationCalibrationOffset.z : 0
-        ) + Vector3.forward * ModConfiguration.Instance.CockpitHeadForwardOffset.Value;
+        ) + Vector3.forward * ModConfiguration.Instance.CockpitHeadForwardOffset.Value
+          + Vector3.right * ModConfiguration.Instance.CockpitHeadRightOffset.Value;
     }
 
 

--- a/NOVR/VrUi/Native/NativeVrUiRoot.cs
+++ b/NOVR/VrUi/Native/NativeVrUiRoot.cs
@@ -4,7 +4,6 @@ using NuclearOption.Networking;
 using NuclearOption.Networking.Lobbies;
 using NuclearOption.Workshop;
 using UnityEngine;
-using UnityEngine.InputSystem;
 using UnityEngine.UI;
 
 namespace NOVR.VrUi.Native;
@@ -20,6 +19,7 @@ public class NativeVrUiRoot : NOVRBehaviour
     private const float RequestedMenuTransitionSeconds = 0.5f;
     private const float MissionLaunchEnvironmentSuppressionSeconds = 8f;
     private const float RecenterDelaySeconds = 2.0f;
+    private const float LiveRecenterDelaySeconds = 3.0f;
     private const float AnchorResetAfterHiddenSeconds = 1.5f;
     private const float MinimumMenuCenterHeightBelowHeadMeters = -0.25f;
     private const float RecenterWidgetDistanceMeters = 1.35f;
@@ -65,6 +65,8 @@ public class NativeVrUiRoot : NOVRBehaviour
     private float _nextMainMenuScanTime;
     private float _pendingRecenterTime;
     private bool _recenterPending;
+    private float _pendingLiveRecenterTime;
+    private bool _liveRecenterPending;
     private float _lastNativeUiVisibleTime = -100f;
     private Vector3 _menuAnchorPosition;
     private Quaternion _menuAnchorRotation = Quaternion.identity;
@@ -199,6 +201,7 @@ public class NativeVrUiRoot : NOVRBehaviour
         HandleRecenterShortcut(shouldShowNativeUi);
         UpdatePlacement(shouldShowNativeUi);
         UpdatePendingRecenter(shouldShowNativeUi);
+        UpdateLivePendingRecenter();
         if (_root != null && _root.activeSelf != shouldShowNativeUi)
         {
             _root.SetActive(shouldShowNativeUi);
@@ -350,13 +353,34 @@ public class NativeVrUiRoot : NOVRBehaviour
 
     private void HandleRecenterShortcut(bool shouldShowNativeUi)
     {
-        if (!shouldShowNativeUi) return;
+        if (!UnityEngine.Input.GetKeyDown(ModConfiguration.Instance.RecenterShortcut.Value)) return;
 
-        var keyboard = Keyboard.current;
-        if (keyboard?.homeKey.wasPressedThisFrame == true)
+        if (shouldShowNativeUi)
         {
             RecenterMenu();
         }
+        else
+        {
+            QueueLiveRecenter();
+        }
+    }
+
+    private void QueueLiveRecenter()
+    {
+        _liveRecenterPending = true;
+        _pendingLiveRecenterTime = Time.unscaledTime + LiveRecenterDelaySeconds;
+        Debug.Log($"[NOVR] Live recenter queued for {LiveRecenterDelaySeconds:0.0} seconds from now.");
+    }
+
+    private void UpdateLivePendingRecenter()
+    {
+        if (!_liveRecenterPending) return;
+        if (Time.unscaledTime < _pendingLiveRecenterTime) return;
+
+        NOVRHeadsetData.CalibrateTranslation();
+        NOVRHeadsetData.CalibrateRotation();
+        _liveRecenterPending = false;
+        Debug.Log("[NOVR] Live recenter applied.");
     }
 
     private void RecenterMenu()

--- a/NOVR/VrUi/Native/NativeVrUiRoot.cs
+++ b/NOVR/VrUi/Native/NativeVrUiRoot.cs
@@ -97,6 +97,8 @@ public class NativeVrUiRoot : NOVRBehaviour
             _menuEnvironment?.Hide();
             ClearNativeCursorProjectionReference();
             SetUtilityWidgetMode(UtilityWidgetMode.Hidden);
+            HandleRecenterShortcut(false);
+            UpdateLivePendingRecenter();
             return;
         }
 


### PR DESCRIPTION
…sions

Switches recenter key detection from UnityEngine.InputSystem.Keyboard (unreliable with this OpenXR/Virtual Desktop setup - raw keyboard events don't reliably reach the new Input System) to the legacy UnityEngine.Input.GetKeyDown API, which works correctly.

Adds a configurable RecenterShortcut key (default F9) and a live-recenter path for use during missions, since previously recenter was only available from the main menu. Mission Launch Environment Suppression logic is untouched.

Tested manually over an extended ~1h session with multiple aircraft
respawns. F9 confirmed working both in the main menu (same code path
as the existing mouse-click "VR CENTER" button) and during missions
(new live-recenter path, 3s delay before calibration fires).