### PR TITLE
Fix tutorial and client-error popups not rendering or clickable in VR

### DIFF
--- a/NOVR/Patches/UI/PopupVrPatch.cs
+++ b/NOVR/Patches/UI/PopupVrPatch.cs
@@ -1,0 +1,78 @@
+using System;
+using HarmonyLib;
+using NOVR.PatchHelper;
+using NOVR.VrUi;
+using NOVR.VrUi.SpecialBehavior;
+using NuclearOption.Networking.Lobbies;
+using UnityEngine;
+
+namespace NOVR.Patches.UI;
+
+/// <summary>
+/// Makes in-game popups usable in VR.
+///
+/// Tutorial dialogue boxes (MissionMessages -> GameplayUI.DialogueBox) live under a
+/// screen-space-overlay canvas the mod never converts, so they are invisible in the
+/// headset and out of reach of the VR cursor. They get adopted onto a world-space
+/// popup canvas when shown.
+///
+/// Multiplayer "client error" messages (FlashErrorMessageSingleton) come with their own
+/// DontDestroyOnLoad overlay canvas, which is converted in place to world space.
+/// </summary>
+internal static class PopupVrPatch
+{
+    private static readonly AccessTools.FieldRef<FlashErrorMessageSingleton, Canvas>? FlashErrorCanvasRef =
+        CreateFlashErrorCanvasRef();
+
+    private static AccessTools.FieldRef<FlashErrorMessageSingleton, Canvas>? CreateFlashErrorCanvasRef()
+    {
+        try
+        {
+            return AccessTools.FieldRefAccess<FlashErrorMessageSingleton, Canvas>("_canvas");
+        }
+        catch (Exception ex)
+        {
+            Debug.LogWarning($"PopupVrPatch: could not bind FlashErrorMessageSingleton._canvas: {ex.Message}");
+            return null;
+        }
+    }
+
+    // EnableBox(true) is the single funnel every DialogueBox.Show path goes through.
+    [PatchPostfix(typeof(DialogueBox), "EnableBox")]
+    private static void DialogueBox_EnableBox_Postfix(DialogueBox __instance, bool __0)
+    {
+        if (!__0 || __instance == null) return;
+
+        try
+        {
+            NOVRPopupCanvasHost.Adopt(__instance);
+        }
+        catch (Exception ex)
+        {
+            Debug.LogWarning($"PopupVrPatch: failed to adopt DialogueBox into VR popup canvas: {ex}");
+        }
+    }
+
+    [PatchPostfix(typeof(FlashErrorMessageSingleton), "ShowErrorInternal")]
+    private static void FlashError_ShowErrorInternal_Postfix(FlashErrorMessageSingleton __instance)
+    {
+        if (__instance == null || FlashErrorCanvasRef == null) return;
+
+        try
+        {
+            var canvas = FlashErrorCanvasRef(__instance);
+            if (canvas == null) return;
+
+            if (!canvas.TryGetComponent<NOVRPopupCanvasBehavior>(out var behavior))
+            {
+                behavior = canvas.gameObject.AddComponent<NOVRPopupCanvasBehavior>();
+            }
+
+            behavior.EnsureConfigured();
+        }
+        catch (Exception ex)
+        {
+            Debug.LogWarning($"PopupVrPatch: failed to convert flash error canvas for VR: {ex}");
+        }
+    }
+}

--- a/NOVR/VrUi/Components/NOVRPopupCanvasBehavior.cs
+++ b/NOVR/VrUi/Components/NOVRPopupCanvasBehavior.cs
@@ -1,0 +1,58 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace NOVR.VrUi.SpecialBehavior;
+
+/// <summary>
+/// Converts a popup canvas that the base game renders in screen space (tutorial dialogue
+/// boxes, multiplayer client-error messages) into a world-space canvas on the VrUi layer,
+/// so the CockpitHudCamera renders it in the headset and the VR cursor can click it.
+/// </summary>
+public class NOVRPopupCanvasBehavior : UIRenderedCanvasBehavior
+{
+    // Same scale as the gameplay/menu canvases, but slightly closer than their 3m plane
+    // so popups draw in front of them instead of z-fighting on the same plane.
+    private const float CanvasScale = 0.003f;
+    private static readonly Vector3 CanvasPosition = new(0f, 0f, 2.8f);
+    private const int PopupSortingOrder = 100;
+
+    public void EnsureConfigured()
+    {
+        var canvas = GetComponent<Canvas>();
+        if (canvas != null)
+        {
+            canvas.renderMode = RenderMode.WorldSpace;
+            if (canvas.worldCamera == null)
+            {
+                canvas.worldCamera = NOUIManager.I != null ? NOUIManager.I.CockpitHudCamera : null;
+            }
+            canvas.sortingOrder = PopupSortingOrder;
+
+            if (GetComponent<GraphicRaycaster>() == null)
+            {
+                gameObject.AddComponent<GraphicRaycaster>();
+            }
+        }
+
+        LayerHelper.SetLayerRecursive(transform, LayerHelper.GetVrUiLayer());
+    }
+
+    // Popup contents are pooled/instantiated at show time (e.g. FlashErrorMessageModal),
+    // so new children need the VrUi layer applied as they appear.
+    private void OnTransformChildrenChanged()
+    {
+        LayerHelper.SetLayerRecursive(transform, LayerHelper.GetVrUiLayer());
+    }
+
+    private void Update()
+    {
+        transform.localScale = new Vector3(CanvasScale, CanvasScale, CanvasScale);
+        transform.position = CanvasPosition;
+
+        var canvas = GetComponent<Canvas>();
+        if (canvas != null && canvas.worldCamera == null && NOUIManager.I != null)
+        {
+            canvas.worldCamera = NOUIManager.I.CockpitHudCamera;
+        }
+    }
+}

--- a/NOVR/VrUi/NOVRPopupCanvasHost.cs
+++ b/NOVR/VrUi/NOVRPopupCanvasHost.cs
@@ -1,0 +1,55 @@
+using NOVR.VrUi.SpecialBehavior;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace NOVR.VrUi;
+
+/// <summary>
+/// Owns a lazily created world-space canvas that adopts popup UI which the base game
+/// parents under screen-space-overlay canvases the mod never converts (e.g. the tutorial
+/// DialogueBox under GameplayUI's gameplay canvas). Overlay canvases are not rendered to
+/// the HMD at all, so anything left under them is invisible and unclickable in VR.
+/// The host canvas lives in the active scene and is recreated on demand after scene loads.
+/// </summary>
+public static class NOVRPopupCanvasHost
+{
+    private const float ReferenceWidth = 1920f;
+    private const float ReferenceHeight = 1080f;
+
+    private static Canvas? _canvas;
+
+    public static Canvas GetOrCreateCanvas()
+    {
+        if (_canvas != null) return _canvas;
+
+        var go = new GameObject("NOVRPopupCanvas");
+        _canvas = go.AddComponent<Canvas>();
+        _canvas.renderMode = RenderMode.WorldSpace;
+
+        var rect = go.GetComponent<RectTransform>();
+        rect.sizeDelta = new Vector2(ReferenceWidth, ReferenceHeight);
+
+        go.AddComponent<GraphicRaycaster>();
+        go.AddComponent<NOVRPopupCanvasBehavior>().EnsureConfigured();
+
+        return _canvas;
+    }
+
+    /// <summary>
+    /// Reparents the popup onto the host canvas, keeping its layout values so it stays
+    /// where the game's UI design put it relative to a full-screen canvas.
+    /// </summary>
+    public static void Adopt(Component popup)
+    {
+        if (popup == null) return;
+
+        var canvas = GetOrCreateCanvas();
+        if (popup.transform.parent != canvas.transform)
+        {
+            popup.transform.SetParent(canvas.transform, false);
+            Debug.Log($"NOVRPopupCanvasHost: adopted '{popup.gameObject.name}' onto the VR popup canvas");
+        }
+
+        LayerHelper.SetLayerRecursive(canvas.transform, LayerHelper.GetVrUiLayer());
+    }
+}


### PR DESCRIPTION
## Problem
Two kinds of in-game popups were invisible in the headset and unreachable by the VR cursor:

- **Tutorial dialogue boxes** — `MissionMessages` shows them via `GameplayUI.DialogueBox`, which sits under a screen-space-overlay canvas the mod never converts to world space. Unity does not render overlay canvases to the HMD at all.
- **Multiplayer "client error" messages** — `FlashErrorMessageSingleton` instantiates its own `DontDestroyOnLoad` overlay canvas from `GameAssets.flashErrorMessage`, which the mod's canvas patch maps never touch.

## Fix
Three new files, no changes to existing mod code:

- **`NOVRPopupCanvasBehavior`** — converts a popup canvas to `RenderMode.WorldSpace` on the VrUi layer (30), pins it at (0, 0, 2.8) / scale 0.003 (slightly in front of the 3 m gameplay/menu UI plane to avoid coplanar z-fighting), assigns `CockpitHudCamera` as the event camera, and ensures a `GraphicRaycaster` so the existing VrUiCursor virtual-mouse pipeline can click it. Re-applies the layer whenever children change, covering the pooled `FlashErrorMessageModal` instances spawned at show time.
- **`NOVRPopupCanvasHost`** — lazily creates a world-space host canvas and adopts the `DialogueBox` onto it when shown, leaving the rest of the game's overlay canvas untouched.
- **`PopupVrPatch`** — Harmony postfixes on `DialogueBox.EnableBox` and `FlashErrorMessageSingleton.ShowErrorInternal` apply the conversion at show time. This deliberately avoids `UIBehaviorPatcher`'s FixedUpdate queue: tutorial dialogues set `timeScale = 0`, which stalls FixedUpdate and would leave the patch queued forever.

Clicking works through the existing flow: `EnableBox` makes the OS cursor visible via `CursorManager`, which activates VrUiCursor's virtual mouse; the popup canvas raycasts against `CockpitHudCamera` like the already-working menus.

## Verification
- `dotnet build NOVR/NOVR.csproj` — 0 errors, no new warnings from the added files.
- Needs an in-headset smoke test: start a tutorial mission (dialogue box should appear ~2.8 m ahead and the OK button should click), and trigger a multiplayer join error (flash error should render and its cancel button click).

## Note
An older unmerged local branch `feature/in-game-popups` attempted this with a much larger diff (repositioning the whole GameplayUI canvas as a head-following popup and click-forwarders that fire on any click). This PR replaces that approach with a minimal, additive one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)