### PR TITLE
Fix bombing HUD VR projection broken by NO 0.34 TMP migration

### DIFF
--- a/NOVR/VrUi/HarmonyPatches/HUDBombingStateViewPositionPatch.cs
+++ b/NOVR/VrUi/HarmonyPatches/HUDBombingStateViewPositionPatch.cs
@@ -40,8 +40,10 @@ internal static class HUDBombingStateViewPositionPatch
     {
         var alignmentBar = (Image)AlignmentBarField.GetValue(state);
         var ccrpCircle = (Image)CcrpCircleField.GetValue(state);
-        var dropCountdown = (Text)DropCountdownField.GetValue(state);
-        var ccrpFallTime = (Text)CcrpFallTimeField.GetValue(state);
+        // dropCountdown/ccrpFallTime/ccipFallTime became TextMeshProUGUI in NO 0.34 - only the
+        // transform is needed here, so treat them as Component to survive the type change.
+        var dropCountdown = DropCountdownField.GetValue(state) as Component;
+        var ccrpFallTime = CcrpFallTimeField.GetValue(state) as Component;
         var cockpitHudCamera = APIBus.CockpitHudCamera;
         if (alignmentBar == null || cockpitHudCamera == null || !alignmentBar.gameObject.activeSelf)
             return;
@@ -77,7 +79,7 @@ internal static class HUDBombingStateViewPositionPatch
     {
         var ccipPipper = (Image)CcipPipperField.GetValue(state);
         var ccipLine = (Image)CcipLineField.GetValue(state);
-        var ccipFallTime = (Text)CcipFallTimeField.GetValue(state);
+        var ccipFallTime = CcipFallTimeField.GetValue(state) as Component;
         var velocityVector = SceneSingleton<FlightHud>.i.velocityVector;
         var cockpitHudCamera = APIBus.CockpitHudCamera;
         if (ccipPipper == null || ccipLine == null || cockpitHudCamera == null || velocityVector == null || !ccipPipper.enabled)


### PR DESCRIPTION
NO 0.34 changed HUDBombingState's dropCountdown, ccrpFallTime and ccipFallTime fields from UnityEngine.UI.Text to TextMeshProUGUI. The hard (Text) casts threw InvalidCastException every frame, so none of the VR corrections ran: the CCRP alignment bar and CCIP pipper stayed at flat-screen pixel coordinates (far off-center in VR), and the CCIP line was scaled by the distance to the VR-projected velocity vector, making it enormous. Only the transforms of these labels are used, so read them as Component instead - immune to Text/TMP type changes.

Same `as Component` idiom as the 0.4.2 unit-marker fix. Root-caused from the InvalidCastException in Player.log after selecting a bomb loadout in VR (NOVR 0.4.2, game 0.34). Compiles against current main and is deployed locally.