### PR TITLE
Fix GPU detail culling camera in VR

### DIFF
--- a/NOVR/GameplayPatches/DetailRendererVrCameraFix.cs
+++ b/NOVR/GameplayPatches/DetailRendererVrCameraFix.cs
@@ -1,0 +1,52 @@
+using System.Reflection;
+using HarmonyLib;
+using NuclearOption.Effects;
+using UnityEngine;
+
+namespace NOVR.GameplayPatches;
+
+/// <summary>
+/// Keeps Nuclear Option's GPU detail culling attached to NOVR's tracked camera.
+/// </summary>
+internal static class DetailRendererVrCameraFix
+{
+    private static readonly FieldInfo? DetailCameraField =
+        AccessTools.Field(typeof(DetailRenderer), "camera");
+
+    private static DetailRenderer? _boundRenderer;
+    private static Camera? _boundCamera;
+    private static bool _loggedMissingField;
+
+    internal static void BindToTrackedCamera(Camera trackedCamera)
+    {
+        var detailRenderer = DetailRenderer.i;
+        if (trackedCamera == null || detailRenderer == null)
+        {
+            return;
+        }
+
+        if (ReferenceEquals(_boundRenderer, detailRenderer) &&
+            ReferenceEquals(_boundCamera, trackedCamera))
+        {
+            return;
+        }
+
+        if (DetailCameraField == null)
+        {
+            if (!_loggedMissingField)
+            {
+                Debug.LogError("[NOVR.TreeFix] Could not find DetailRenderer.camera; GPU detail culling was not rebound.");
+                _loggedMissingField = true;
+            }
+
+            return;
+        }
+
+        DetailCameraField.SetValue(detailRenderer, trackedCamera);
+        _boundRenderer = detailRenderer;
+        _boundCamera = trackedCamera;
+
+        Debug.Log(
+            $"[NOVR.TreeFix] Bound DetailRenderer GPU detail culling to camera '{trackedCamera.gameObject.name}'.");
+    }
+}

--- a/NOVR/VrCamera/VrCameraManager.cs
+++ b/NOVR/VrCamera/VrCameraManager.cs
@@ -3,6 +3,7 @@ using System;
 using Il2CppInterop.Runtime.InteropTypes.Arrays;
 #endif
 using System.Collections.Generic;
+using NOVR.GameplayPatches;
 using UnityEngine;
 using UnityEngine.Rendering.Universal;
 
@@ -109,6 +110,8 @@ public class VrCameraManager: MonoBehaviour
 
         IgnoredCameras.Add(rootCamera);
         IgnoredCameras.Add(trackedCamera);
+
+        DetailRendererVrCameraFix.BindToTrackedCamera(trackedCamera);
     }
 
     private static void EnsureTrackedMainCameraRig(Camera rootCamera, Camera trackedCamera)
@@ -140,6 +143,8 @@ public class VrCameraManager: MonoBehaviour
 
         IgnoredCameras.Add(rootCamera);
         IgnoredCameras.Add(trackedCamera);
+
+        DetailRendererVrCameraFix.BindToTrackedCamera(trackedCamera);
     }
 
     private void HandleChildCameras(Camera parentCamera)


### PR DESCRIPTION
## What changed

- Rebind Nuclear Option's `DetailRenderer` to NOVR's tracked main camera when the VR rig is created.
- Reapply the binding when an existing rig is recovered after scene or camera recreation.
- Cache the reflected private field and the last successful binding.

## Why

`DetailRenderer.Start()` caches `Camera.main` before NOVR replaces the game's main camera. Its GPU detail/tree culling therefore continues to use the disabled, aircraft-facing camera, causing trees to disappear according to a fixed forward view cone instead of the headset view.

## User impact

GPU detail culling now follows the headset camera. This keeps the game's existing compute-shader frustum and distance culling; it does not force all trees to render.

## Validation

- Built successfully against the current Nuclear Option assemblies as part of the published fork build.
- Repeatedly tested in VR: the binding log appears and trees remain stable while looking behind or to either side of the aircraft.
- Revalidated alongside the production XR-pass zoom implementation in fork release `0.4.3.5`.

Fixes #35
